### PR TITLE
Fix para implementar cloudinary y generar un archivo inicial de carga…

### DIFF
--- a/src/api/data/data_inicial.json
+++ b/src/api/data/data_inicial.json
@@ -1,0 +1,5589 @@
+[
+    {
+        "release": {
+            "titulo": "Theo Parrish - Detroit Beatdown Remixes 1:2",
+            "url_imagen": "https://i.discogs.com/58ybvhDYeZJgOpFpJ96aCc2ZkXssPMX55QKirfOReaI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU0NTMx/OS0xMjg3OTQzMjU5/LmpwZWc.jpeg",
+            "sello": "3EEP-038",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2005",
+            "estilos": "Techno, Deep House"
+        },
+        "tracklist": [
+            {
+                "nombre": "Falling Up (Carl Craig Remix)",
+                "posicion": "A"
+            }
+        ],
+        "artist": {
+            "nombre": "Theo Parrish",
+            "nombre_real": "unasigned",
+            "perfil": "American electronic DJ, and producer. \r\n\r\nBorn: 1972 in Washington DC, USA. \r\n\r\nGrowing up in Chicago, later Detroit-based house music producer, Parrish is internationally well known for his own inimitable downtempo house music style. \r\n\r\nHe is also a label owner, with both [l=Sound Signature] and [l=Ugly Edits] probably being his best known ones. \r\n",
+            "url_imagen": "https://i.discogs.com/w9ZO-BukhS00EfqGlf8RnoTKBvPGNUssA8n27qltDQE/rs:fit/g:sm/q:90/h:382/w:334/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE0OS0x/NTA0ODIwNTIyLTcz/NzUuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "I-f - Space Invaders Are Smoking Grass",
+            "url_imagen": "https://i.discogs.com/zpRrLPlxDJWwqs5oA0kZ61eN6mFODcQRGi9j8jUVP8Q/rs:fit/g:sm/q:90/h:595/w:595/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5NDYw/LTExNDgyNDU4ODAu/anBlZw.jpeg",
+            "sello": "IT No. 9",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1998",
+            "estilos": "Electro"
+        },
+        "tracklist": [
+            {
+                "nombre": "Space Invaders Are Smoking Grass (Extended 12\" Version)",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Untitled",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Space Invaders Are Smoking Grass (Original)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Secret Desire (Instrumental)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "I-f",
+            "nombre_real": "unasigned",
+            "perfil": "Dutch DJ and producer. I-f, short for [a=Interr-Ference], also known as Ferenc, [a=Beverly Hills 808303].",
+            "url_imagen": "https://i.discogs.com/fHKqm9v8EVfvUQ8pJlmsewyOVgW70Cc9EzlfamvwKRg/rs:fit/g:sm/q:90/h:399/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE0NjAt/MTQ5MjA4NTI2OC04/OTI5LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Sound Stream - \"Live\" Goes On",
+            "url_imagen": "https://i.discogs.com/AMaHeADkq7toetZP7n9ncn9nKSYURL8KvsiRy6Rkl0s/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0MzM2/NTAtMTQ3OTI1ODQz/Ny00MTM4LmpwZWc.jpeg",
+            "sello": "SST 04",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "Germany",
+            "publicado": "2008",
+            "estilos": "House, Deep House, Disco"
+        },
+        "tracklist": [
+            {
+                "nombre": "\"Live\" Goes On",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Rainmaker",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Dance With Me",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "Sound Stream",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/rRf7BIFcH8cuBHbc5bhfsWS2CrAZkGzYCqQ1bW_sZXc/rs:fit/g:sm/q:90/h:446/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwMDk4/LTE0Mjc0NDQ2NDAt/NDg2NC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "John B - Up All Night / Take Control",
+            "url_imagen": "https://i.discogs.com/WENvqOMA_QvDc_l__rut1_BykZ9icB68JVT5rLjlHD4/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM3OTQt/MTYwNjgxMjk5My01/MjA0LmpwZWc.jpeg",
+            "sello": "METH 041",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2001",
+            "estilos": "Drum n Bass"
+        },
+        "tracklist": [
+            {
+                "nombre": "Up All Night",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Take Control",
+                "posicion": "AA"
+            }
+        ],
+        "artist": {
+            "nombre": "John B",
+            "nombre_real": "unasigned",
+            "perfil": "Drum & Bass DJ & producer, based in the UK. \r\nOwns & runs the [l=Beta Recordings] label, along with its sublabels: [l=Chihuahua Recordings], [l=Nu Electro Recordings], [l=Tangent Recordings].\r\n",
+            "url_imagen": "https://i.discogs.com/tWPWa0pZ_BlQ2JzLyHyhvCsnAXhjmPhzaMleARBmAX0/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwOS0x/NjkwMDc0Mzg2LTIy/ODYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Tim Hecker - Ravedeath, 1972",
+            "url_imagen": "https://i.discogs.com/u_sMg6x0q_rAeeRobsHsWL-U3iB7xu9Sn3cV1ddPORU/rs:fit/g:sm/q:90/h:594/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI3NDQ3/NzctMTMwNDE5OTUz/NC5qcGVn.jpeg",
+            "sello": "krank154",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "2011",
+            "estilos": "Abstract, Ambient, Experimental, Drone"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Piano Drop",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "In The Fog: I-II",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "In The Fog: III",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "No Drums",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Hatred Of Music: I",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Hatred Of Music: II",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Analog Paralysis, 1978",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "Studio Suicide, 1980",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "In The Air: I-III",
+                "posicion": "D"
+            }
+        ],
+        "artist": {
+            "nombre": "Tim Hecker",
+            "nombre_real": "unasigned",
+            "perfil": "Tim Hecker is an electronic musician and sound artist based in Los Angeles, United States and Montreal, Canada. Hecker initially recorded under the moniker Jetone, but has become known internationally for recordings released under his own name.\r\n\r\nHas worked for the government.",
+            "url_imagen": "https://i.discogs.com/FlSSBRySwtl74do9nrLvFo_xma0A-RwMz9A_jRptffA/rs:fit/g:sm/q:90/h:771/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU5OTA2/LTE1MzMyNDc3MzQt/NTYzNy5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Mathew Jonson - Decompression EP",
+            "url_imagen": "https://i.discogs.com/CkRsG4rdYyTSW9usMOsAdepbEjiK3_Q1Cz8qJt63G5Q/rs:fit/g:sm/q:90/h:595/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMxMzc0/NC0xNjMxMTkzMzc2/LTI2NzMuanBlZw.jpeg",
+            "sello": "MINUS24",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "Canada",
+            "publicado": "2004",
+            "estilos": "Techno, Minimal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Decompression",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Ultraviolet Dream",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Mathew Jonson",
+            "nombre_real": "unasigned",
+            "perfil": "Canadian electronic music producer, performer and label owner, born in Vancouver but now based in Berlin (Germany). He is one of the founders of [l=Wagon Repair] and in 2012 he became the new owner of [l=Itiswhatitis Recordings].\r\n\r\nHe is the brother of [a=Nathan Jonson], [a=Holly Jonson].",
+            "url_imagen": "https://i.discogs.com/aUOEWiAxBMCb0BWzamMDgYrStSG92ZLbaIkCAWphSpA/rs:fit/g:sm/q:90/h:400/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTUyMDAw/LTE0NDg4MTg0NDUt/NTI3NC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Motor City Drum Ensemble - Raw Cuts # 3 / Raw Cuts # 4",
+            "url_imagen": "https://i.discogs.com/-8U6wVQ5UrhLljH2Gk8KVQSbEIQ8Vb-K58vSFtFyJEc/rs:fit/g:sm/q:90/h:490/w:490/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0ODcx/MzktMTM0MzA2NTM3/OC02ODQ2LmpwZWc.jpeg",
+            "sello": "MCDE 1202",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "Netherlands",
+            "publicado": "2008",
+            "estilos": "Deep House, Disco"
+        },
+        "tracklist": [
+            {
+                "nombre": "Raw Cuts # 3",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Raw Cuts # 4",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Motor City Drum Ensemble",
+            "nombre_real": "unasigned",
+            "perfil": "Primary alias of Danilo Plessow, a house producer and DJ from Stuttgart, Germany. ",
+            "url_imagen": "https://i.discogs.com/0kESMPw0B_KgU-gOpKMtUcws5DA9fEo0YJgI4PmtvTk/rs:fit/g:sm/q:90/h:314/w:431/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3MDkw/NS0xNTEwNzU1MTQw/LTc4MDEuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Daft Punk - Alive 2007 / Alive 1997",
+            "url_imagen": "https://i.discogs.com/JP10P3RCIE-P_hYLBTzLJTT3zGNofWvkbFdIIRQq4Pc/rs:fit/g:sm/q:90/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5NDEw/NTgtMTI1Mzg4Njc4/MS5qcGVn.jpeg",
+            "sello": "5099996753422",
+            "formato": "Box Set",
+            "genero": "Electronic",
+            "pais": "France",
+            "publicado": "2009",
+            "estilos": "House, Abstract, Disco, Techno, Electro, Experimental"
+        },
+        "tracklist": [
+            {
+                "nombre": "Alive 2007",
+                "posicion": ""
+            },
+            {
+                "nombre": "Robot Rock",
+                "posicion": "1-01"
+            },
+            {
+                "nombre": "Oh Yeah",
+                "posicion": "1-02"
+            },
+            {
+                "nombre": "Touch It",
+                "posicion": "1-03"
+            },
+            {
+                "nombre": "Technologic",
+                "posicion": "1-04"
+            },
+            {
+                "nombre": "Television Rules The Nation",
+                "posicion": "1-05"
+            },
+            {
+                "nombre": "Crescendolls",
+                "posicion": "1-06"
+            },
+            {
+                "nombre": "Too Long",
+                "posicion": "1-07"
+            },
+            {
+                "nombre": "Steam Machine",
+                "posicion": "1-08"
+            },
+            {
+                "nombre": "Around The World",
+                "posicion": "1-09"
+            },
+            {
+                "nombre": "Harder Better Faster Stronger",
+                "posicion": "1-10"
+            },
+            {
+                "nombre": "Burnin'",
+                "posicion": "1-11"
+            },
+            {
+                "nombre": "Too Long",
+                "posicion": "1-12"
+            },
+            {
+                "nombre": "Face To Face",
+                "posicion": "1-13"
+            },
+            {
+                "nombre": "Short Circuit",
+                "posicion": "1-14"
+            },
+            {
+                "nombre": "One More Time",
+                "posicion": "1-15"
+            },
+            {
+                "nombre": "Aerodynamic",
+                "posicion": "1-16"
+            },
+            {
+                "nombre": "Aerodynamic Beats",
+                "posicion": "1-17"
+            },
+            {
+                "nombre": "Forget About The World",
+                "posicion": "1-18"
+            },
+            {
+                "nombre": "Prime Time Of Your Life",
+                "posicion": "1-19"
+            },
+            {
+                "nombre": "Brainwasher",
+                "posicion": "1-20"
+            },
+            {
+                "nombre": "Rollin' And Scratchin'",
+                "posicion": "1-21"
+            },
+            {
+                "nombre": "Alive",
+                "posicion": "1-22"
+            },
+            {
+                "nombre": "Da Funk",
+                "posicion": "1-23"
+            },
+            {
+                "nombre": "Daftendirekt",
+                "posicion": "1-24"
+            },
+            {
+                "nombre": "Superheroes",
+                "posicion": "1-25"
+            },
+            {
+                "nombre": "Human After All",
+                "posicion": "1-26"
+            },
+            {
+                "nombre": "Rock'n Roll",
+                "posicion": "1-27"
+            },
+            {
+                "nombre": "Alive 1997",
+                "posicion": ""
+            },
+            {
+                "nombre": "Wdpk Part 1",
+                "posicion": "2a"
+            },
+            {
+                "nombre": "Da Funk",
+                "posicion": "2b"
+            },
+            {
+                "nombre": "Rollin' And Scratchin'",
+                "posicion": "2c"
+            },
+            {
+                "nombre": "Wdpk Part 2",
+                "posicion": "2d"
+            },
+            {
+                "nombre": "Alive",
+                "posicion": "2e"
+            }
+        ],
+        "artist": {
+            "nombre": "Daft Punk",
+            "nombre_real": "unasigned",
+            "perfil": "Daft Punk were a French electronic music duo formed in 1993 by [a=Thomas Bangalter] (born January 3, 1975) and [a=Guy-Manuel de Homem-Christo] (born February 8, 1974). Bangalter and de Homem-Christo were previously in the rock band [a=Darlin'] with [a=Laurent Brancowitz]. After Brancowitz left the group to join his brother's band, [a=Phoenix], the remaining duo formed Daft Punk. On February 22, 2021, it was announced that they had disbanded for unknown reasons.",
+            "url_imagen": "https://i.discogs.com/sP_wDoC5MsG9lZUfb9thLbpmMmL__nuVnGMNpwgjirE/rs:fit/g:sm/q:90/h:438/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyODkt/MTYxNTQ4NDUyOS00/Mjg0LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "2 Bad Mice - Hold It Down",
+            "url_imagen": "https://i.discogs.com/KLqJB-tIoR0JlWqYnH0xBg1esb2p-haAiIxTGOzLJcw/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxMTct/MTI4ODQ1NTg1NS5q/cGVn.jpeg",
+            "sello": "SHADOW 14",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1992",
+            "estilos": "Breakbeat, Hardcore"
+        },
+        "tracklist": [
+            {
+                "nombre": "This Side",
+                "posicion": ""
+            },
+            {
+                "nombre": "Bomb Scare",
+                "posicion": "X1"
+            },
+            {
+                "nombre": "2 Bad Mice (Remix)",
+                "posicion": "X2"
+            },
+            {
+                "nombre": "Other Side",
+                "posicion": ""
+            },
+            {
+                "nombre": "Hold It Down",
+                "posicion": "Y1"
+            },
+            {
+                "nombre": "Ware Mouse",
+                "posicion": "Y2"
+            }
+        ],
+        "artist": {
+            "nombre": "2 Bad Mice",
+            "nombre_real": "unasigned",
+            "perfil": "Formed in 1991, 2 Bad Mice (the name originating from The Tale of 2 Bad Mice by Beatrix Potter) are widely credited as among the first U.K. hardcore acts to begin heavily incorporating breakbeats into the style. Consisting of members Sean O'Keeffe, Simon Colebrooke and producer Rob Playford (owner of Moving Shadow records), 2 Bad Mice were a staple on the early-to mid '90s hardcore scene and were instrumental in the music's steady mutation into jungle/drum'n'bass. The group's influential approach to sampled beats -- cutting them up into shards of rhythm and rearranging them in novel combinations (first appearing in mature form on the 1992 hit \"Bombscare\") is generally considered the blueprint from which jungle's characteristic manipulation of breaks was assembled. \r\n\r\nAlthough 2 Bad Mice for the most part stopped producing as the hardcore scene began to wane (Playford focusing his energy on Moving Shadow, now one of the most influential jungle labels), a best-of compilation of the group's work appeared on the American Sm:)e Communications label in 1995. These days Playford continues to work in production, while O'Keeffe, Colebrooke (and Paul Rhodes) currently DJ worldwide as 2 Bad Mice. ",
+            "url_imagen": "https://i.discogs.com/7f6YIt2QTGGemhaRHpeQcJ8NS79KmbL8Yfi4-6Wz1RA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwNzYt/MTY0OTcxNDQ4My02/MjY1LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Autechre - Oversteps",
+            "url_imagen": "https://i.discogs.com/RM2Tli20zio7oEGywwaKEkSsh2LhfMBstDM4CI2GB8Y/rs:fit/g:sm/q:90/h:540/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIxOTIw/NTMtMTM3OTQ2OTE5/OS0zMTk1LmpwZWc.jpeg",
+            "sello": "WARPCD210",
+            "formato": "CD",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2010",
+            "estilos": "Abstract, IDM, Ambient"
+        },
+        "tracklist": [
+            {
+                "nombre": "r ess",
+                "posicion": "1"
+            },
+            {
+                "nombre": "ilanders",
+                "posicion": "2"
+            },
+            {
+                "nombre": "known(1)",
+                "posicion": "3"
+            },
+            {
+                "nombre": "pt2ph8",
+                "posicion": "4"
+            },
+            {
+                "nombre": "qplay",
+                "posicion": "5"
+            },
+            {
+                "nombre": "see on see",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Treale",
+                "posicion": "7"
+            },
+            {
+                "nombre": "os veix3",
+                "posicion": "8"
+            },
+            {
+                "nombre": "O=0",
+                "posicion": "9"
+            },
+            {
+                "nombre": "d-sho qub",
+                "posicion": "10"
+            },
+            {
+                "nombre": "st epreo",
+                "posicion": "11"
+            },
+            {
+                "nombre": "redfall",
+                "posicion": "12"
+            },
+            {
+                "nombre": "krYlon",
+                "posicion": "13"
+            },
+            {
+                "nombre": "Yuop",
+                "posicion": "14"
+            }
+        ],
+        "artist": {
+            "nombre": "Autechre",
+            "nombre_real": "unasigned",
+            "perfil": "An English electronic music duo formed in 1987 in Rochdale, Greater Manchester, UK by [a=Rob Brown (3)] and [a=Sean Booth]. Generally considered to be IDM in style, their music has incorporated a variety of genres and styles ranging from techno and hip hop to ambient, experimental electro, and musique concrète. Autechre use many different digital and analog synthesizers, samplers, and drum machines in their production. They are also heavily involved with the [a=Gescom] collective.",
+            "url_imagen": "https://i.discogs.com/8-BdhyrSloFj_ieDxcoRiVb3ghUtwYDyLRsuA5Aplbg/rs:fit/g:sm/q:90/h:326/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQxLTEz/NjczNDQ3NDktMzM0/Mi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Coil Presents Black Light District - A Thousand Lights In A Darkened Room",
+            "url_imagen": "https://i.discogs.com/v7LTTMCsKN7igpLfkO-GVjjUSUQu2AVZXKgbJFH_r4M/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4MzQ2/Mi0xMjcwOTQzOTgw/LmpwZWc.jpeg",
+            "sello": "ESKATON 008",
+            "formato": "CD",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1996",
+            "estilos": "Experimental, Minimal, Ambient"
+        },
+        "tracklist": [
+            {
+                "nombre": "Unprepared Piano",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Red Skeletons",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Die Wölfe Kommen Zurück",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Refusal Of Leave To Land",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Stoned Circular I",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Stoned Circular II",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Green Water",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Cold Dream Of An Earth Star",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Blue Rats",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Scratches And Dust",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Chalice",
+                "posicion": "11"
+            }
+        ],
+        "artist": {
+            "nombre": "Coil",
+            "nombre_real": "unasigned",
+            "perfil": "Formed in London in 1983 by [a=John Balance] as a solo side project to Psychic TV, Coil developed into a full-scale musical group in 1984, when Balance cemented a partnership with Peter 'Sleazy' Christopherson. Christopherson had been a founder of Psychic TV and member of Throbbing Gristle. \r\nJohn Balance (1962–2004) died tragically in an accident at his home on November 13th, 2004.\r\nPeter Christopherson decided that, with the passing of John Balance, Coil would not continue.\r\nPeter Martin Christopherson died 25 November 2010 (aged 55).",
+            "url_imagen": "https://i.discogs.com/tULNZQb7PuNXUDwoJ_gx46KUag91H46c98o2QFBd64o/rs:fit/g:sm/q:90/h:664/w:450/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY2MC0x/NTM3MDAxOTAyLTM0/NDIuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Moodymann - Silence In The Secret Garden",
+            "url_imagen": "https://i.discogs.com/PJyEvph256nP5jN87VD1xiBfaQ50yQfSxA9CPb3R120/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE1MDU1/My0xMzM0NDE1NDM0/LmpwZWc.jpeg",
+            "sello": "PFG036",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2003",
+            "estilos": "Deep House, Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "Entrance 2 The Garden",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "People",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Backagainforthefirsttime?",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "LiveInLA 1998",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "P.B.C.",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Shine",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Yesterdays Party Watta Bout It",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Silence In The Secret Garden",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "On My Way Home",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "Sweet Yesterday",
+                "posicion": "D2"
+            }
+        ],
+        "artist": {
+            "nombre": "Moodymann",
+            "nombre_real": "unasigned",
+            "perfil": "DJ and producer based in Detroit, Michigan.",
+            "url_imagen": "https://i.discogs.com/PbFRCxt2v2zbQv_kZgOx7fTGKZk41gSB3C64GxR_Sig/rs:fit/g:sm/q:90/h:365/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwOTQt/MTI5MTQ2Mzg5Ni5q/cGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Basic Channel - Octagon / Octaedre",
+            "url_imagen": "https://i.discogs.com/-lKhTTTGZYrRu9B8K8Lb-PWfEbaY2YNWWlqcK88OLVQ/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM1NDMt/MTEyODk0ODU3OS5q/cGVn.jpeg",
+            "sello": "BC 07",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "Germany",
+            "publicado": "1994",
+            "estilos": "Techno, Dub Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "Octagon",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Octaedre",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Basic Channel",
+            "nombre_real": "unasigned",
+            "perfil": "Basic Channel is a German techno production duo and [url=https://www.discogs.com/label/255-Basic-Channel]record label[/url], composed of Moritz von Oswald and Mark Ernestus, that originated in Berlin in 1993.\r\nThe duo became known in the mid-1990s for a series of vinyl-only releases under various aliases marked by minimalism in both production techniques and graphic esthetics. Basic Channel is widely regarded as a pioneering force of minimal and dub techno.\r\nThe minimalist esthetics of the 12\"s released by the duo / label can lead to ambiguities as to whether the names listed on releases are aliases / project names or just track / release titles, meaning that appearances of those tracks on compilations or DJ mixes were often inconsistently credited.",
+            "url_imagen": "https://i.discogs.com/RKOOdjyBKp8DZ8SII9j9LlPVV3UMFQInyTukmHkgDWY/rs:fit/g:sm/q:90/h:450/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzMTE3/LTEzMTM1OTE4MjMu/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Green Velvet - The Stalker",
+            "url_imagen": "https://i.discogs.com/nGfj_TY066bLIvsLA-c6UvZFmdmAznQy6p6Lq4RcFEw/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYyNzkt/MTU4ODE4MDczNy03/MTQ3LmpwZWc.jpeg",
+            "sello": "RR 764",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1996",
+            "estilos": "House, Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Stalker (I'm Losing My Mind)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Help Me",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Pegal",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "Green Velvet",
+            "nombre_real": "unasigned",
+            "perfil": "American electronic DJ, producer, and artist. \r\n\r\nBorn: 26 April 1968 in Chicago, Illinois, USA. \r\n\r\nGreen Velvet, initially created by house don [a=Cajmere] (AKA [a=Curtis Alan Jones]) as an outlet for his non-vocal productions and frequent DJ-ing gigs, grew to become even more popular than the man himself, thanks to club singles like \"Preacher Man\", \"Answering Machine\", and \"The Stalker\". \r\n\r\nJones, who had nurtured the Chicago house renaissance of the 1990s with his [l=Cajual Records], gained success in 1993 with the [a=Cajmere] single \"Brighter Days\" (with [a=Dajaé] on vocals). Later that year, he formed the sublabel [l=Relief Records], mostly for instrumental tracks by himself and others. \r\n\r\nBesides releases from [a=DJ Sneak], [a=Gemini], and [a=Paul Johnson], Green Velvet figured on many of the early Relief singles, including its first, \"Preacher Man\" as well as \"Flash\" (also released on the British label [l=Open]), \"The Stalker\", and \"Answering Machine\" (1997). \r\n\r\nHe began to supplement his Green Velvet DJ-ing schedule with quasi-live gigs as well, and released his first album in 1999. His self-titled release on label [l=F-111 Records] a year later compiled a dozen of his earlier club hits, and the proper sophomore production album \"Whatever\" (2001) appeared on his own Relief label. \r\n",
+            "url_imagen": "https://i.discogs.com/Uxs1r_JAIYObQYwPQxjOf2FyGjGL0AnaYoXXm6nUgrw/rs:fit/g:sm/q:90/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIxOS0x/Mzk2NDQwNDk4LTI4/ODYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "FKA Twigs - M3LL155X",
+            "url_imagen": "https://i.discogs.com/OtKvrVvVJkvR_-ed2RThwORVLwcOWcZy3dIgR1Af7FA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc4MDI2/MDAtMTQ0OTA4NTE5/Ny0xOTc0LmpwZWc.jpeg",
+            "sello": "YT142",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2015",
+            "estilos": "Trip Hop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Figure 8",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "I'm Your Doll",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "In Time",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Glass & Patron",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Mothercreep",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "FKA Twigs",
+            "nombre_real": "unasigned",
+            "perfil": "Tahliah Barnett, born January 16th 1988 in Gloucestershire, is a British musician & dancer.\r\nShe has Jamaican & Spanish roots & currently lives in London, United Kingdom.",
+            "url_imagen": "https://i.discogs.com/rokFNZ7T0w1OFKD7I-Otr9pKtPnAtGkQv_zFVmpei98/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM0NTIx/NTctMTYzOTk0Njcw/MS05NTcwLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Ed Rush, Optical & Fierce - Cutslo (Lokuste Mix) / Alien Girl",
+            "url_imagen": "https://i.discogs.com/yj1jJwPhEUilwopzrbx2-keieT4T9HNegIYb4PrsmEs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgzMi0x/MzA2NTcwOTUxLmpw/ZWc.jpeg",
+            "sello": "PRO 014",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1998",
+            "estilos": "Drum n Bass"
+        },
+        "tracklist": [
+            {
+                "nombre": "Cutslo (Lokuste Mix)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Alien Girl",
+                "posicion": "AA"
+            }
+        ],
+        "artist": {
+            "nombre": "Ed Rush",
+            "nombre_real": "unasigned",
+            "perfil": "Drum n Bass producer based in London. \r\n\r\nHe saved up for his first set of decks whilst working on the fish counter in Sainsburys. His debut DJing gig was at The Brain in London. Linked up with [a=DJ Trace] through Don FM, and [a168579] was his neighbour. This led to them starting to make tracks together, and the eventual formation of No Turn. Also DJed on Flex FM.\r\n\r\nForms the duo [a=Ed Rush & Optical] with [a=Optical] aka [a=Matt Quinn].",
+            "url_imagen": "https://i.discogs.com/3cD7L1xKJEj46MqUkniWg7rLfl0N3uiqDPed8YnFzn0/rs:fit/g:sm/q:90/h:805/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwOC0x/NTQyOTc3Njc5LTY4/NDcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "X-Press 2 - Muzik Xpress",
+            "url_imagen": "https://i.discogs.com/azD6N3VkZkDd3ewIaRmP57fSa1ExfSC5J5c4fZ5uhV4/rs:fit/g:sm/q:90/h:597/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI0NDA4/LTEyMjM5MDc0NjYu/anBlZw.jpeg",
+            "sello": "JBO 8-12",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1992",
+            "estilos": "Progressive House, House"
+        },
+        "tracklist": [
+            {
+                "nombre": "Muzik Xpress",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Muzik Xpress (Double D Mix)",
+                "posicion": "AA1"
+            },
+            {
+                "nombre": "Muzik Xpress (Rock 2 House Beats)",
+                "posicion": "AA2"
+            }
+        ],
+        "artist": {
+            "nombre": "X-Press 2",
+            "nombre_real": "unasigned",
+            "perfil": "British house project.",
+            "url_imagen": "https://i.discogs.com/SqmkoPwKy0vNgi0ii94CFN2d2mvMIXAMgepoa0kZRxk/rs:fit/g:sm/q:90/h:280/w:380/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI5Mzct/MTU0MDk4MDA2My02/OTg3LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Earth People - Dance",
+            "url_imagen": "https://i.discogs.com/qloR_19Kp4WV1ZZmusRLGKyDfqbynqtZGcB_SZ_MhOI/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY2MzAz/LTE1NzYzMjU5MjMt/MjM4NC5qcGVn.jpeg",
+            "sello": "AP 146",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1990",
+            "estilos": "House"
+        },
+        "tracklist": [
+            {
+                "nombre": "Dance (Club Mix)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Dance (Dub Mix)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Dance (Beats)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "Earth People",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/8pxIn1tpGLVNQlBzob1oURgEkaYLD3CdGClNM075oPM/rs:fit/g:sm/q:90/h:472/w:391/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ2MDUt/MTY0NzE2OTU2My0z/NDMzLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Orbital - Funny Break (One Is Enough)",
+            "url_imagen": "https://i.discogs.com/jyMajzcJeSaTS4dPrKBHv1HMCQwuegv1plKR4zPPWyA/rs:fit/g:sm/q:90/h:587/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQzMjg3/LTEzMDAzMDM2MzMu/anBlZw.jpeg",
+            "sello": "FX395",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK & Europe",
+            "publicado": "2001",
+            "estilos": "Breakbeat, Progressive Trance"
+        },
+        "tracklist": [
+            {
+                "nombre": "Funny Break (One Is Enough) (Weekend Ravers Mix)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Funny Break (One Is Enough) (Plump DJ's Mix)",
+                "posicion": "AA"
+            }
+        ],
+        "artist": {
+            "nombre": "Orbital",
+            "nombre_real": "unasigned",
+            "perfil": "Techno outfit founded in the late 80s by the brothers Paul and Phil Hartnoll.",
+            "url_imagen": "https://i.discogs.com/WMm1pA_Qidl7LjAVGIDb6GiZQKQVqXlHVqbj6Lp9hb4/rs:fit/g:sm/q:90/h:580/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyNzkt/MTY4MDI4NTEwMC01/OTk1LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Jeff Mills - Our Man From Havana",
+            "url_imagen": "https://i.discogs.com/Fo_zv8cN4MfOxTmB_xLba0SRStm2rhlUobmeyVDzmFc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0NS0x/MzA2ODcwMzA1Lmpw/ZWc.jpeg",
+            "sello": "PM-004",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1997",
+            "estilos": "Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Fly Guy",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Calypso High",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Cubango",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Sugar Is Sweeter",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "Jeff Mills",
+            "nombre_real": "unasigned",
+            "perfil": "American techno DJ, composer, producer, and recording artist, based in Detroit, Michigan, USA. \r\n\r\nBorn: 18 June 1963 in Detroit, Michigan, USA. \r\n\r\nJeff Mills (aka \"The Wizard\") is one of the most pioneering American names in techno music. Championed for his music's relentless pursuit of hardness and his stripped-down, almost industrial DJ sets, Mills is the latest in a long line of Detroit-bred talent to take on an international reputation, performing for audiences around the world in both club and art spaces. \r\n\r\nHe also runs his own label, [l=Axis], and its several sublabels. Married to [a=Yoko Uozumi].",
+            "url_imagen": "https://i.discogs.com/RkUGj_cGVM_D6GxvCkZ90K1bs3Rq5zczx0H0UCk5ZMc/rs:fit/g:sm/q:90/h:790/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwNS0x/NTA1ODA5NzQ5LTc5/MTAuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Jimi Hendrix Experience* - Smash Hits",
+            "url_imagen": "https://i.discogs.com/NpVLAExGumG_7TQWVzqQzFLeCkwLOQzrNEdZVRXVOTM/rs:fit/g:sm/q:90/h:531/w:531/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5Njg4/MDMtMTI1NTcxMzY5/Ni5qcGVn.jpeg",
+            "sello": "613004",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "UK",
+            "publicado": "1968",
+            "estilos": "Blues Rock, Psychedelic Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Purple Haze",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Fire",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "The Wind Cries Mary",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Can You See Me",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "51st Anniversary",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Hey Joe",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Stone Free",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "The Stars That Play With Laughing Sam's Dice",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Manic Depression",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Highway Chile",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "The Burning Of The Midnight Lamp",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Foxy Lady",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "The Jimi Hendrix Experience",
+            "nombre_real": "unasigned",
+            "perfil": "The Jimi Hendrix Experience (often shortened to The Experience) was a band comprising guitarist/singer/songwriter [a110593], bassist/backing vocalist/songwriter [a252848], and drummer/backing vocalist [a252849]. Formed in London, England in October 1966 by ex-Animals bassist [a254160], The Experience were active for just under three years, a run which resulted in three successful studio albums and four top 10 singles.",
+            "url_imagen": "https://i.discogs.com/N4_Cs1TMOq2yDmo4FgRSxxzKa_xRXFjI_mJ2mOnK6ao/rs:fit/g:sm/q:90/h:455/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1NTY3/Mi0xNjQ0Mzg3Nzky/LTY1MzAuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Van Halen - Fair Warning",
+            "url_imagen": "https://i.discogs.com/aEFOJOTH443ENG-3q_y0maWK_nP738rf4WAEVN-BctE/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwODA1/NjUtMTM1ODM4NDcy/NS05Nzk4LmpwZWc.jpeg",
+            "sello": "HS 3540",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1981",
+            "estilos": "Hard Rock, Heavy Metal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Mean Street",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "\"Dirty Movies\"",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Sinner's Swing!",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Hear About It Later",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Unchained",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Push Comes To Shove",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "So This Is Love?",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Sunday Afternoon In The Park",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "One Foot Out The Door",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Van Halen",
+            "nombre_real": "unasigned",
+            "perfil": "American rock band formed in Pasadena, California in 1974 by Dutch brothers Eddie and Alex Van Halen. From 1974 until 1985, the band consisted of the Van Halens (guitar and drums, respectively); vocalist David Lee Roth; and bassist/vocalist Michael Anthony. In 1985, Roth left the band to embark on a solo career and was replaced by former Montrose lead vocalist Sammy Hagar. With Hagar, the group released four  albums over the course of 11 years. Former Extreme frontman Gary Cherone replaced Hagar in 1996, before parting ways in 1999. Van Halen then went on hiatus until reuniting with Hagar in 2003 for a worldwide tour in 2004. Hagar again left Van Halen in 2005. In 2006 Roth returned, but Anthony was replaced on bass guitar by Eddie's son, Wolfgang Van Halen. In 2012, the band released their final studio album. It was also Van Halen's first album with Roth in 28 years and the only one to feature Wolfgang. \r\n\r\n[a211671] died on the 6th October 2020 at St. Johns Hospital, Santa Monica, California after a long battle with throat cancer.",
+            "url_imagen": "https://i.discogs.com/4WwTrwoISipufS1BmrZVJuCo4QCPOhie0CaLWtkHsKA/rs:fit/g:sm/q:90/h:414/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk0MDY2/LTE2Mjc2NjA0Nzgt/MjI2Ny5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "My Chemical Romance - Three Cheers For Sweet Revenge",
+            "url_imagen": "https://i.discogs.com/HAglwKeMK095cuf0Vo4Ub2u21tmpw2c8LGYtcFjza_4/rs:fit/g:sm/q:90/h:475/w:475/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUzMzky/Mi0xMTI4NTQ0Mzgz/LmpwZWc.jpeg",
+            "sello": "48615-2",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "2004",
+            "estilos": "Emo, Pop Punk"
+        },
+        "tracklist": [
+            {
+                "nombre": "Helena",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Give 'Em Hell, Kid",
+                "posicion": "2"
+            },
+            {
+                "nombre": "To The End",
+                "posicion": "3"
+            },
+            {
+                "nombre": "You Know What They Do To Guys Like Us In Prison",
+                "posicion": "4"
+            },
+            {
+                "nombre": "I'm Not Okay (I Promise)",
+                "posicion": "5"
+            },
+            {
+                "nombre": "The Ghost Of You",
+                "posicion": "6"
+            },
+            {
+                "nombre": "The Jetset Life Is Gonna Kill You",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Interlude",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Thank You For The Venom",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Hang 'Em High",
+                "posicion": "10"
+            },
+            {
+                "nombre": "It's Not A Fashion Statement, It's A Deathwish",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Cemetery Drive",
+                "posicion": "12"
+            },
+            {
+                "nombre": "I Never Told You What I Do For A Living",
+                "posicion": "13"
+            }
+        ],
+        "artist": {
+            "nombre": "My Chemical Romance",
+            "nombre_real": "unasigned",
+            "perfil": "My Chemical Romance is an American rock band from New Jersey, formed in 2001. The band consists of lead vocalist Gerard Way, guitarists Ray Toro and Frank Iero, and bassist Mikey Way. Shortly after forming, the band signed to Eyeball Records and released their debut album I Brought You My Bullets, You Brought Me Your Love in 2002. They signed with Reprise Records the next year and released their major label debut Three Cheers for Sweet Revenge in 2004; the album was a commercial success, and was awarded platinum status a little over a year later. The band eclipsed their previous success with their 2006 concept album, The Black Parade, which gained generally favorable reviews among music critics. They have since finished recording their fourth studio album, Danger Days: The True Lives of the Fabulous Killjoys, which was released in November 2010. On March 22, 2013, the band announced their break up. On October 31, 2019, the band announced a reunion, with an opening show in Los Angeles. ",
+            "url_imagen": "https://i.discogs.com/33riI2JfENvqcZpSuWNedaW_M_3vUimaBIlJXrjEA_Q/rs:fit/g:sm/q:90/h:926/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMxOTQw/Ni0xNjUyNDE3NDE1/LTc3MDEuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Journey - Frontiers",
+            "url_imagen": "https://i.discogs.com/mlgCG1bQ23Fh5EiZasjs2t7TBHqAgGbkESiquWSDJTA/rs:fit/g:sm/q:90/h:595/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0NTU0/MjEtMTQ1MDYzMTc0/Mi00ODQ0LmpwZWc.jpeg",
+            "sello": "QC 38504",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1983",
+            "estilos": "AOR, Classic Rock, Arena Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Separate Ways (Worlds Apart)",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Send Her My Love",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Chain Reaction",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "After The Fall",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Faithfully",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Edge Of The Blade",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Troubled Child",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Back Talk",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Frontiers",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Rubicon",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Journey",
+            "nombre_real": "unasigned",
+            "perfil": "Journey is an American rock band that formed in San Francisco in 1973, composed of former members of Santana and Frumious Bandersnatch. The band has gone through several phases; its strongest commercial success occurred between 1978 and 1987. ",
+            "url_imagen": "https://i.discogs.com/PHQW1YJ1wg6ka0zo292uaPRsmRU1rOJ4mHVbXeokIWw/rs:fit/g:sm/q:90/h:399/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyODM5/NS0xNjYyMTQ0ODQ4/LTcyOTQuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Queens Of The Stone Age - Villains",
+            "url_imagen": "https://i.discogs.com/CJBZeqN_PDN6MufPoftohqHPBmp2bY_rGL89knOXeMc/rs:fit/g:sm/q:90/h:529/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNzQw/NDQxLTE1MDM2OTMx/MzEtNTY4MC5qcGVn.jpeg",
+            "sello": "OLE-1125-2",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "2017",
+            "estilos": "Alternative Rock, Stoner Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Feet Don't Fail Me",
+                "posicion": "1"
+            },
+            {
+                "nombre": "The Way You Used To Do",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Domesticated Animals",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Fortress",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Head Like A Haunted House",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Un-Reborn Again",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Hideaway",
+                "posicion": "7"
+            },
+            {
+                "nombre": "The Evil Has Landed",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Villains Of Circumstance",
+                "posicion": "9"
+            }
+        ],
+        "artist": {
+            "nombre": "Queens Of The Stone Age",
+            "nombre_real": "unasigned",
+            "perfil": "Alternative Rock/Stoner band formed in 1997 in Palm Desert, California, United States.",
+            "url_imagen": "https://i.discogs.com/8cbUGW0vpHxzJfROUGTAyXDU_JxXwmFXKhZ5aYjnXvw/rs:fit/g:sm/q:90/h:400/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU2MTY4/LTE2NjAyNzQ1OTQt/NTE1NS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Sublime (2) - Sublime",
+            "url_imagen": "https://i.discogs.com/TMKnolk-9biVhos_H_haWhI_NmoMs3OkQfqb__a3bEY/rs:fit/g:sm/q:90/h:590/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY0NDc4/MS0xNTU2OTA4MTE5/LTUyOTEuanBlZw.jpeg",
+            "sello": "GASD-11413",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1996",
+            "estilos": "Ska, Punk"
+        },
+        "tracklist": [
+            {
+                "nombre": "Garden Grove",
+                "posicion": "1"
+            },
+            {
+                "nombre": "What I Got",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Wrong Way",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Same In The End",
+                "posicion": "4"
+            },
+            {
+                "nombre": "April 29, 1992 (Miami)",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Santeria",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Seed",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Jailhouse",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Pawn Shop",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Paddle Out",
+                "posicion": "10"
+            },
+            {
+                "nombre": "The Ballad Of Johnny Butt",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Burritos",
+                "posicion": "12"
+            },
+            {
+                "nombre": "Under My Voodoo",
+                "posicion": "13"
+            },
+            {
+                "nombre": "Get Ready",
+                "posicion": "14"
+            },
+            {
+                "nombre": "Caress Me Down",
+                "posicion": "15"
+            },
+            {
+                "nombre": "What I Got (Reprise)",
+                "posicion": "16"
+            },
+            {
+                "nombre": "Doin' Time",
+                "posicion": "17"
+            }
+        ],
+        "artist": {
+            "nombre": "Sublime (2)",
+            "nombre_real": "unasigned",
+            "perfil": "American band from Long Beach, California formed in 1988 and stopped in 1996. Known as a ska punk band, Sublime also had influences from hardcore punk, reggae, dancehall, dub, folk, hip hop...\r\n\r\nSublime disbanded after their singer Brad Nowell died of a heroin overdose on 25th May 1996, only two months before their self-titled album was released. In 1997, members would formed [a719179]. In 2009, the surviving members Bud Gaugh and Eric Wilson attempted to reform Sublime with Rome Ramirez as their new singer and guitarist, but due to a lawsuit, the band was forced to change their name to [A=Sublime With Rome].\r\n",
+            "url_imagen": "https://i.discogs.com/8QnfS_foSYM17S1U9WNFQh_MTVegfmUPencJx7Qf1jo/rs:fit/g:sm/q:90/h:718/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk4NjAw/LTE1MzUwNTkzNzQt/MjU1NS5wbmc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Rolling Stones* - Steel Wheels",
+            "url_imagen": "https://i.discogs.com/lDkCMDkORUfPnG7ptznwQPZOq_sE0szmxT5Gb3GP-SQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0NDQz/Mi0xNTIzNjkzMTA0/LTE2NDcuanBlZw.jpeg",
+            "sello": "465752 1",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "Europe",
+            "publicado": "1989",
+            "estilos": "Blues Rock, Hard Rock, Ballad, Funk, Rock & Roll"
+        },
+        "tracklist": [
+            {
+                "nombre": "Sad Sad Sad",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Mixed Emotions",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Terrifying",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Hold On To Your Hat",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Hearts For Sale",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Blinded By Love",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Rock And A Hard Place",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Can't Be Seen",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Almost Hear You Sigh",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Continental Drift",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Break The Spell",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Slipping Away",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "The Rolling Stones",
+            "nombre_real": "unasigned",
+            "perfil": "English rock band formed in London in May 1962. They are one of the longest-lived and most commercially successful groups in rock history. Inducted into the Rock And Roll Hall of Fame in 1989 (Performer).\r\n\r\n[i]Band members[/i]\r\n\r\n[u]05/1962 - 05/1963[/u]\r\n[a255182] (Keyboards, piano)\r\n\r\n[u]05/1962 - 06/1969[/u]\r\n[a409290] (Lead and rhythm guitars)\r\n\r\n[u]06/1962 - 10/1962[/u]\r\n[a414255] (Bass)\r\n\r\n[u]06/1962 - 12/1962[/u]\r\n[a677434] (Drums)\r\n\r\n[u]06/1962 - present[/u]\r\n[a90541] (Lead vocals, harmonica, percussion)\r\n[a166570] (Lead and rhythm guitars, acoustic guitar, backing vocals)\r\n\r\n[u]12/1962 - 01/1993[/u]\r\n[a272814] (Bass)\r\n\r\n[u]01/1963 - 08/2021[/u]\r\n[a299325] (Drums and percussion)\r\n\r\n[u]07/1969 - 12/1974[/u]\r\n[a300117] (Lead and slide guitars)\r\n\r\n[u]03/1975 - present[/u]\r\n[a271311] (Guitars, backing vocals)",
+            "url_imagen": "https://i.discogs.com/H3bmFFLnkb4qDTzFQtLRbvMjBNs8bR8R7Zz0JJcMP14/rs:fit/g:sm/q:90/h:690/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwOTkx/LTE2NTY5NjI2MTUt/OTA3Ny5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Roxy Music - Country Life",
+            "url_imagen": "https://i.discogs.com/IHJN7kN8disVWJNLjxa8Lkv5n2XwrIFeQ5GYzXlm1vY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY3MjMw/My0xNDc3MTY3NTkz/LTMxODkuanBlZw.jpeg",
+            "sello": "ILPS 9303",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "UK",
+            "publicado": "1974",
+            "estilos": "Art Rock, Avantgarde, Glam"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Thrill Of It All",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Three And Nine",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "All I Want Is You",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Out Of The Blue",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "If It Takes All Night",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Bitter-Sweet",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Triptych",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Casanova",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "A Really Good Time",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Prairie Rose",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Roxy Music",
+            "nombre_real": "unasigned",
+            "perfil": "Roxy Music were an English rock band formed in 1970 by [a87721], who became the band's lead vocalist and chief songwriter, and bassist [a439088]. Alongside Ferry, the other longtime members were [a10351] (guitar), [a267770] (saxophone and oboe) and [a261914] (drums and percussion), and other former members include [a634] (synthesizer and \"treatments\"), [a262493] (synthesiser and violin), and [a355635] (bass). Although the band took a break from group activities in 1976 and again in 1983, they reunited for a concert tour in 2001, and toured together intermittently between that time and their break-up in 2011. Ferry frequently enlisted members of Roxy Music as session musicians for his solo releases.\r\n\r\nInducted into the Rock & Roll Hall of Fame in 2019 (Performers) and Roxy Music frontman [a87721] was awarded a CBE by Her Majesty the Queen of England on 30 November 2011.\r\n\r\nDiscogs records that Roxy Music have released 28 albums and 38 compilations since the band’s inception back in 1971. Of these, 18 have made the ‘UK Top 40’ music charts with 11 of them reaching the ‘Top 10’ and 4 albums reaching the No.1 position. The albums to hit the top spot are ‘[m=58357]’ (Dec 1973), ‘[m=41847]’ (May 1980), ‘[m=58313]’ (Jun 1982) and ‘[m58362]’ (Apr 1986). These four albums cumulatively spent 13 weeks at the No.1 position. All 18 charting albums, have in total, been in the chart’s Top 10 for 76 weeks and within the Top 40 for 260 weeks.\r\n\r\nSimilarly, Roxy Music have had success with some of their 49 single/EP releases. In this case, there has been a chart entry for 18 of these releases, with one single making the No.1 spot. In February 1981, Roxy Music hit the singles chart 'top spot' with the John Lennon composed song ‘[m=58331]’ and spent 2 weeks at that coveted position, 9 weeks in the chart’s Top 40 (6 weeks in the Top 10) and 11 weeks overall.\r\n\r\nThe 18 Roxy Music hit singles/EPs have spent time in the UK Top 40 music charts for 128 weeks, with 44 of these within the Top 10. The single with the most time in the UK Charts is ‘[m=58323]’, which entered the charts in April 1979 and overall spent 14 weeks charting.\r\n\r\nRoxy Music’s first album to enter the UK Charts was the self-entitled ‘[m=58135]’ (Island ILPS9200) making its debut on 29/07/1972.  It stayed in the charts for 16 weeks with its highest position being no.10. The album briefly reappeared in February 2018 under the HDCD release (Virgin ROXYCD1) for one week reaching no.47. The first single to chart for Roxy Music was ‘[m=58141]’ (Island WIP6144) on 19/08/1972 and it remained in the UK charts for 12 weeks achieving a high position of no.4 in its fifth week on the charts. (Source: Official Charts Company (UK) (April 2020)).",
+            "url_imagen": "https://i.discogs.com/LN0Y9NANjOjQJMlu1n6y5wbEkuj0P0D0145fJfaYPgs/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU2NjIx/LTE1Njk3NjgxNzMt/NzEwOS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "George Harrison - Cloud Nine",
+            "url_imagen": "https://i.discogs.com/OCacWd9XbKY7hCA2b24moUw3Jcd4JWrfa-g58Ik6BHc/rs:fit/g:sm/q:90/h:590/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNTE0/OTgtMTQ0Mzc5ODk4/My04MjM5LmpwZWc.jpeg",
+            "sello": "WX 123",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "UK",
+            "publicado": "1987",
+            "estilos": "Pop Rock, Classic Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Cloud 9",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "That’s What It Takes",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Fish On The Sand",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Just For Today",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "This Is Love",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "When We Was Fab",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Devil’s Radio",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Someplace Else",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Wreck Of The Hesperus",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Breath Away From Heaven",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Got My Mind Set On You",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "George Harrison",
+            "nombre_real": "unasigned",
+            "perfil": "British rock guitarist, singer-songwriter and film producer (born February 25 1943 in Liverpool, England, UK - died November 29, 2001 in Los Angeles, California, USA). Best known as lead guitarist of [a82730].\r\nBy the mid-1960s, he had become an admirer of Indian culture and mysticism, introducing it to the other Beatles. In 1968, he travelled with the other Beatles to Rishikesh, in northern India, to study meditation with [a=Maharishi Mahesh Yogi]. He embraced the Hare Krishna tradition, particularly japa-yoga chanting with beads, and became a lifelong devotee.\r\nInducted into Rock And Roll Hall of Fame in 2004 (Performer).\r\nIn June 1965, he and the other Beatles were appointed Members of the Order of the British Empire (MBE). They received their insignia from the Queen at an investiture at Buckingham Palace on 26 October. In 1988, he was inducted into the Rock and Roll Hall of Fame as a member of The Beatles. He was honoured posthumously with the 2.382nd star on the Hollywood Walk of Fame on 14 April 2009.\r\nMarried to [a1401442] from 21 January 1966 to 1977. Married to [a907704] from 2 September 1978 to his death. Father of [a726756] (with Olivia Harrison). Youngest brother of [a2450148].",
+            "url_imagen": "https://i.discogs.com/XVa3tGLLsa7O3c8dVEVeOLHYmF4Lps-KdgDZmtaGmQg/rs:fit/g:sm/q:90/h:854/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI0Mzk1/NS0xNjAwNDY4MjYw/LTc4NzkuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Death (2) - Leprosy",
+            "url_imagen": "https://i.discogs.com/TobnHiSjMC4QSmdaEjfx-wQ6YPJ-VEBYJ_UXY84Te9s/rs:fit/g:sm/q:90/h:605/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ2ODIz/My0xNDc0NjY1Nzg4/LTY0NDEuanBlZw.jpeg",
+            "sello": "88561-8248-1",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1988",
+            "estilos": "Death Metal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Leprosy",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Born Dead",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Forgotten Past",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Left To Die",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Pull The Plug",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Open Casket",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Primitive Ways",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Choke On It",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "Death (2)",
+            "nombre_real": "unasigned",
+            "perfil": "Formed in 1983 as [url=https://www.discogs.com/artist/1787042-Mantas-3]Mantas[/url] with Chuck Schuldiner on vocals and guitar, Rick Rozz on guitar and Barney 'Kam' Lee on drums and vocals. In 1984 the band recorded their first demo called \"Death By Metal\". Soon after the recording the band split up and Chuck formed a new band named Death.\r\n\r\n1984: Rick Rozz (guitar), Kam Lee (drums), Chuck Schuldiner (guitar, vocals).\r\n1985: Rick Rozz leaves the band. Scott Carlson (bass) and Matt Olivio (guitar) from the Michigan based band Genocide joined Death. Kam left the band. A couple of months later both Matt and Scott left. Chuck moved to San Francisco and joined forces with Eric Brecht (drums). At the end of the year Chuck returned to Florida bandless.\r\n1986: Chuck moved to Toronto to join Slaughter. After a couple of weeks Chuck moved back to Florida and then once again to San Francisco to join up with drummer Chris Reifert. During rehearsals Steve DiGiorgio played bass while Death and [a=Sadus] shared a rehearsal space. They recorded \"Scream Bloody Gore\" during the summer.\r\n1987: \"Scream Bloody Gore\" released March 1987. Chuck moved back to Florida and teamed up with Rick Rozz (guitar), Terry Butler (bass) and Bill Andrews (drums).\r\n1988: Rick Rozz replaced by James Murphy.\r\n1990: James Murphy replaced by Albert Gonzales who in the same year was replaced by Paul Masvidal. The band decided to tour Europe without Chuck with Walter Trachsler on guitar and Louie Carrisalez handling the vocals. \r\n1991: Chuck recruits Sean Reinert (drums), Paul Masvidal (guitar) and Steve DiGiorgio (bass). Steve DiGiorgio replaced by Skott Carino.\r\n1993: Paul Masvidal and Sean Reinert leaves replaced by Andy LaRocque (guitar) and Gene Hoglan (drums) and Steve DiGiorgio rejoins. Craig Locicero helps out on their European tour and Ralph Santolla on the US tour and the Easter festivals in Europe. \r\n1995: Bobby Koelble on guitar and Kelly Conlon on bass. \r\n1996: A break so Chuck can think about the band's future. During this period Chuck starts the band [a=Control Denied].\r\n1998: Shannon Hamm on guitar, Scott Clendenin on bass and Richard Christy on drums.\r\n1999: Chuck is diagnosed with a brainstem tumor.\r\n2001: \"Live In L.A.\" and \"Live In Eindhoven\" albums were released by Nuclear Blast to earn some money for Chuck's treatment. Chuck passed away on December 13th that year.\r\n",
+            "url_imagen": "https://i.discogs.com/YXTa2dDSduOuQrn9mZRTZPX00zu1Tup8i7-teOF-EXw/rs:fit/g:sm/q:90/h:564/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1NDI2/OC0xNTUwNjI3NjUx/LTM5NDcuZ2lm.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Bob Seger & The Silver Bullet Band* - Live Bullet",
+            "url_imagen": "https://i.discogs.com/1SifcMYzaXwcNLJf5RAEc7PmPx9K8-AT1ydyDx43uJA/rs:fit/g:sm/q:90/h:600/w:597/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNjUw/MDAtMTM4MzcxNTIx/OC03OTYyLmpwZWc.jpeg",
+            "sello": "SKBB-11523",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1976",
+            "estilos": "AOR, Hard Rock, Classic Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Nutbush City Limits",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Travelin' Man",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Beautiful Loser",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Jody Girl",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "I've Been Working",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Turn The Page",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "U.M.C.",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Bo Diddley",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Ramblin' Gamblin' Man",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Heavy Music",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "Katmandu",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "Lookin' Back",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "Get Out Of Denver",
+                "posicion": "D2"
+            },
+            {
+                "nombre": "Let It Rock",
+                "posicion": "D3"
+            }
+        ],
+        "artist": {
+            "nombre": "Bob Seger And The Silver Bullet Band",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/wYYcfzfgAcd5RN6Lt09oyNaSfM4x1cVsNJAXRzC1HNs/rs:fit/g:sm/q:90/h:399/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2ODkx/MS0xNTI4NjU1NDEz/LTk1MzcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Bryan Adams - Cuts Like A Knife",
+            "url_imagen": "https://i.discogs.com/3TK3zyJ4eIIGsv4RB5qd7lJbG1xFZumM_GU0e4y1LX8/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE1Njc1/MDktMTMxOTYyMzM4/My5qcGVn.jpeg",
+            "sello": "SP 4919",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "Canada",
+            "publicado": "1983",
+            "estilos": "Pop Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Only One",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Take Me Back",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "This Time",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Straight From The Heart",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Cuts Like A Knife",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "I'm Ready",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "What's It Gonna Be",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Don't Leave Me Lonely",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Let Him Know",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "The Best Was Yet To Come",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Bryan Adams",
+            "nombre_real": "unasigned",
+            "perfil": "Canadian rock singer, guitarist and photographer, born November 5th, 1959, in Ontario. His recording debut was at the age of fifteen, with the glam rock band [a816901].  After a third version of Roxy Roller and one album entitled \"If Wishes Were Horses\", he went solo by releasing one disco single before striking out on a pop career.\r\n\r\n[b]Please note that Bryan Adams the singer-songwriter and Bryan Adams the [i]photographer[/i] are one and the same. This profile should be used for photo credits as well.[/b]",
+            "url_imagen": "https://i.discogs.com/tnPL6y3eCiB4XU_S0AUykfUdqgmP0a4NaAH_LAih7qE/rs:fit/g:sm/q:90/h:413/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwOTMz/LTE0NzQwNDQzNzUt/OTc2Ni5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Pink Floyd - Another Brick In The Wall (Part II)",
+            "url_imagen": "https://i.discogs.com/7gdVsro3t9U9jxHgodxKvL23oItFOac60wZJ1syWVYM/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUxMDM1/OC0xMjc1NDA2ODQ5/LmpwZWc.jpeg",
+            "sello": "HAR 5194",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "UK",
+            "publicado": "1979",
+            "estilos": "Pop Rock, Prog Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Another Brick In The Wall (Part II)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "One Of My Turns",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Pink Floyd",
+            "nombre_real": "unasigned",
+            "perfil": "Pink Floyd was an English rock band from London. Founded in 1965, the group achieved worldwide acclaim, initially with innovative psychedelic music, and later in a genre that came to be termed progressive rock.\r\n\r\nDistinguished by philosophical lyrics, musical experimentation, frequent use of sound effects and elaborate live shows, Pink Floyd remains one of the most commercially successful and influential groups in the history of popular music.\r\n\r\n[a=David Gilmour] – guitar, slide guitar, vocals (1968-2014)\r\n[a=Richard Wright] – keyboards, vocals (1965-1980, 1987-2008)\r\n[a=Nick Mason] – drums, percussion, sound effects (1965-2014)\r\n[a=Roger Waters] – bass guitar, vocals, sound effects (1965-1985)\r\n[a=Syd Barrett] – guitar, vocals (1965-1968)\r\n\r\n[b]Other players:[/b]\r\n[a=Rado Klose] – guitar (1965)\r\n[a=Jon Carin] – backing vocals, keyboards, slide guitar, sound effects (1985-1995)\r\n[a=Guy Pratt] – bass guitar, backing vocals (1987-1995)\r\n\r\nInducted into Rock And Roll Hall of Fame in 1996 (Performer).\r\nGroup name was taken from both [a=Pink Anderson] and [a=Floyd \"Dipper Boy\" Council] as a tribute to the American blues music they loved.",
+            "url_imagen": "https://i.discogs.com/jQidWO3_h7lBerDbfbxxGkp7qnjxo6OTEhT06EWrQ1A/rs:fit/g:sm/q:90/h:670/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ1NDY3/LTE0ODgxMTYxMTEt/Nzc3OC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Mad Season - Above",
+            "url_imagen": "https://i.discogs.com/8AbBEUdlU1dAYo3-h7uOZTdRs9ZOjOot7LFTEsWFxFM/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM2ODIz/NC0xMzE0OTMxODI0/LmpwZWc.jpeg",
+            "sello": "CK 67057",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1995",
+            "estilos": "Alternative Rock, Grunge"
+        },
+        "tracklist": [
+            {
+                "nombre": "Wake Up",
+                "posicion": "1"
+            },
+            {
+                "nombre": "X-Ray Mind",
+                "posicion": "2"
+            },
+            {
+                "nombre": "River Of Deceit",
+                "posicion": "3"
+            },
+            {
+                "nombre": "I'm Above",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Artificial Red",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Lifeless Dead",
+                "posicion": "6"
+            },
+            {
+                "nombre": "I Don't Know Anything",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Long Gone Day",
+                "posicion": "8"
+            },
+            {
+                "nombre": "November Hotel",
+                "posicion": "9"
+            },
+            {
+                "nombre": "All Alone",
+                "posicion": "10"
+            }
+        ],
+        "artist": {
+            "nombre": "Mad Season",
+            "nombre_real": "unasigned",
+            "perfil": "Mad Season were a super-group in the Seattle scene in the 1990s, featuring [a=Layne Staley] of [a=Alice in Chains], [a=Mike McCready] of [a=Pearl Jam], [a=Barrett Martin] of [a=Screaming Trees], and [a=John Baker Saunders] of [url=http://www.discogs.com/artist/99923-Walkabouts-The]The Walkabouts[/url]. The band only existed for one album. \r\n\r\nJohn Baker Saunders passed away in 1999 from a heroin overdose. Layne Staley passed away in 2002.\r\n\r\nLine-up:\r\nLayne Staley - vocals, guitar\r\nMike McCready - guitars\r\nJohn Baker Saunders - bass\r\nBarrett Martin - drums, percussion",
+            "url_imagen": "https://i.discogs.com/Bsbol9UNafAFfIBd8eOKOeQOgZ7zbUMwue7C6lhRONM/rs:fit/g:sm/q:90/h:476/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY5OTUz/LTEzOTQyMTM0NTYt/MjQyMi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Opeth - Blackwater Park",
+            "url_imagen": "https://i.discogs.com/vO-YtwrhCtZ6eOITSFN2bDgR3N-9otSfIEcr8wCw2Zs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwMDA4/My0xMzI1MjQwNjM0/LmpwZWc.jpeg",
+            "sello": "CDMFN 264",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "Europe",
+            "publicado": "2001",
+            "estilos": "Acoustic, Death Metal, Progressive Metal"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Leper Affinity",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Bleak",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Harvest",
+                "posicion": "3"
+            },
+            {
+                "nombre": "The Drapery Falls",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Dirge For November",
+                "posicion": "5"
+            },
+            {
+                "nombre": "The Funeral Portrait",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Patterns In The Ivy",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Blackwater Park",
+                "posicion": "8"
+            }
+        ],
+        "artist": {
+            "nombre": "Opeth",
+            "nombre_real": "unasigned",
+            "perfil": "Swedish progressive metal band from Stockholm, formed in 1990. Though the group has been through several personnel changes, singer, guitarist, and songwriter [a=Mikael Åkerfeldt] has remained Opeth's driving force throughout the years. Opeth has consistently incorporated progressive, folk, blues, classical and jazz influences into their usually lengthy compositions, as well as strong influences from black metal and death metal, especially in their early works. Many songs include acoustic guitar passages and strong dynamic shifts, as well as both death growls and clean vocals. Opeth rarely made live appearances supporting their first four albums; but since conducting their first world tour after the 2001 release of [i]Blackwater Park[/i], they have led several world tours.\r\n\r\nIn 2011, they published [i]Heritage[/i]. It represents a drastic change in style from their previous albums, adopting a mostly progressive rock sound and only clean singing. Åkerfeldt commented on the diversity of Opeth's music: \"I don't see the point of playing in a band and going just one way when you can do everything. It would be impossible for us to play just death metal; that is our roots, but we are now a mishmash of everything, and not purists to any form of music. It's impossible for us to do that, and quite frankly I would think of it as boring to be in a band that plays just metal music. We're not afraid to experiment, or to be caught with our pants down, so to speak. That's what keeps us going.\" (Metal Hammer)\r\n\r\nOn August 26, 2014, Opeth released its eleventh studio album, titled [i]Pale Communion[/i]. Fredrik Åkesson, spoke about the new direction the band was taking: \"It would be interesting to do a really heavy album, but in a different way. Not to go back, we're not about that. I'm still very proud with the last two albums, I think it's interesting to listen to them, even if I listen in an objective way.\" (Ultimate Guitar)\r\n\r\nIn 2016, Opeth founded their own label, [l1067696] and published the twelfth studio album \"Sorceress.\"",
+            "url_imagen": "https://i.discogs.com/Dx1-wecwstyviNwrJVdNibsYsP82RfKio0lf3oaKOz4/rs:fit/g:sm/q:90/h:511/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI0NTc5/Ny0xNjYzNTk4OTMz/LTQwMzUuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Minor Threat - Minor Threat",
+            "url_imagen": "https://i.discogs.com/S5HQdmAuR-rjwZgD89pIpJUxCxi-xCcmrSyBRot9Ato/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1ODg0/MDctMTM0MTM2OTg0/MC0yNzcxLmpwZWc.jpeg",
+            "sello": "DISCHORD № 12",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1984",
+            "estilos": "Punk, Hardcore"
+        },
+        "tracklist": [
+            {
+                "nombre": "Filler",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "I Don't Wanna Hear It",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Seeing Red",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Straight Edge",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Small Man, Big Mouth",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Screaming At A Wall",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Bottled Violence",
+                "posicion": "A7"
+            },
+            {
+                "nombre": "Minor Threat",
+                "posicion": "A8"
+            },
+            {
+                "nombre": "In My Eyes",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Out Of Step (With The World)",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Guilty Of Being White",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Steppin' Stone",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "Minor Threat",
+            "nombre_real": "unasigned",
+            "perfil": "Influential American hardcore punk band from Washington, D.C. formed in 1980 and disbanded in 1983. \r\nTheir song \"Straight Edge\" gave birth to the straight edge movement, which emphasized a lifestyle without alcohol and drugs.",
+            "url_imagen": "https://i.discogs.com/kg-XZh-VCCxSaT3tLRCODUgz8zOc82GlZ-DjNV0eY2Y/rs:fit/g:sm/q:90/h:418/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1MjIw/Mi0xNjIxODI1MzQz/LTM4ODYucG5n.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Flaming Lips - The Soft Bulletin",
+            "url_imagen": "https://i.discogs.com/Rmh-8oU0wJ8HI9fN7_ZhDXyiIr371o2Yfi7IE4l9l_E/rs:fit/g:sm/q:90/h:588/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNzIy/NjYtMTIzNTMzMTY0/My5qcGVn.jpeg",
+            "sello": "9 46876-2",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1999",
+            "estilos": "Psychedelic Rock, Experimental, Indie Rock, Noise Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Race For The Prize (Remix)",
+                "posicion": "1"
+            },
+            {
+                "nombre": "A Spoonful Weighs A Ton",
+                "posicion": "2"
+            },
+            {
+                "nombre": "The Spark That Bled",
+                "posicion": "3"
+            },
+            {
+                "nombre": "The Spiderbite Song",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Buggin' (Remix)",
+                "posicion": "5"
+            },
+            {
+                "nombre": "What Is The Light?",
+                "posicion": "6"
+            },
+            {
+                "nombre": "The Observer",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Waitin' For A Superman",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Suddenly Everything Has Changed",
+                "posicion": "9"
+            },
+            {
+                "nombre": "The Gash",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Feeling Yourself Disintegrate",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Sleeping On The Roof",
+                "posicion": "12"
+            },
+            {
+                "nombre": "Race For The Prize",
+                "posicion": "13"
+            },
+            {
+                "nombre": "Waitin' For A Superman (Remix)",
+                "posicion": "14"
+            }
+        ],
+        "artist": {
+            "nombre": "The Flaming Lips",
+            "nombre_real": "unasigned",
+            "perfil": "The Flaming Lips are an American psychedelic rock band formed in 1983 in Oklahoma City, OK, USA.\r\nThe band currently consists of Wayne Coyne (vocals, guitar, keyboards), Steven Drozd (guitars, keyboards, bass, vocals), Derek Brown (keyboards, guitars, percussion), Matt Duckworth Kirksey (drums, percussion, keyboards) and Nicholas Ley (percussion, drums).",
+            "url_imagen": "https://i.discogs.com/_WuWw4dubAKivI_FVohYJ-k4FhvKfCBnjSvqecUeaow/rs:fit/g:sm/q:90/h:364/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY3MTU2/LTEzMTU5NTYyODAu/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Blur - Blur",
+            "url_imagen": "https://i.discogs.com/cpvJYUr-m7ZHpHwIBe_U_KL-76BE9HQr6qp5MY9ky4k/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwNjMy/MS0xMTM5ODYzMDA4/LmpwZWc.jpeg",
+            "sello": "FOOD LP 19",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "UK",
+            "publicado": "1997",
+            "estilos": "Alternative Rock, Britpop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Beetlebum",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Song 2",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Country Sad Ballad Man",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "M.O.R.",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "On Your Own",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Theme From Retro",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "You're So Great",
+                "posicion": "A7"
+            },
+            {
+                "nombre": "Death Of A Party",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Chinese Bombs",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "I'm Just A Killer For Your Love",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Look Inside America",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Strange News From Another Star",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Movin' On",
+                "posicion": "B6"
+            },
+            {
+                "nombre": "Essex Dogs",
+                "posicion": "B7"
+            }
+        ],
+        "artist": {
+            "nombre": "Blur",
+            "nombre_real": "unasigned",
+            "perfil": "Indie rock/pop band with art school roots from London, England.\r\n\r\nBlur formed in 1989 as [a=Seymour] in Colchester, composed of [a=Damon Albarn], [a=Graham Coxon] (1989-2002, 2008- ), [a=Alex James (2)], and [a=Dave Rowntree].\r\nBlur's early releases (the singles \"There's No Other Way\", \"Bang\", \"She's So High\", \"I Know\", and the album \"Leisure\") were considered indie or alternative rock, heavily influenced by the danceable rhythms of \"baggy\" bands like The Stone Roses and noisepop bands like [a=My Bloody Valentine], with strains of weirder ideas running throughout, like Syd Barrett (this was often more readily apparent on several single B-sides, where the group let loose its more atavistic, dark side). By 1992, the group was keen on reinventing themselves with a newer, smarter sound and sense of purpose, eschewing the sounds that were coming out of the U.S. specifically, and returning to a retro spectrum of British rock and pop music: British Invasion groups, Mod groups, Psychedelic Rock, even nostalgic music from World War II. They released their second album, \"Modern Life Is Rubbish\", in 1993, to moderate success and began attracting attention for their stubborn determination to lead Britain out of the miasma that was the grunge years.\r\n\r\nBuilding on the qualified success of \"Modern Life Is Rubbish\" and its accompanying singles, and aided by groups like [a=Suede], Blur rolled out the carpet for the Britpop cultural movement that would all but engulf the UK for two years, releasing in 1994 what was essentially seen by the general public as the Britpop flagship album, \"Parklife\". Everything changed culturally, and Blur was riding the crest of that cultural wave. Following rapidly on the heels of the tipping point that was \"Parklife\", the group's 1995 album \"The Great Escape\" was a vividly nervy and somewhat cartoonish version of the same formula. It left the group with a hangover that it determined it could only cure by taking several steps back from the Britpop sound and culture. The group re-embraced America, digging into influences like Pavement, Dinosaur Jr., The Pixies.\r\n\r\nBy the time Blur's fifth studio album, \"Blur\", came out in 1997, the group had all but severed ties from Britpop and were returning to the same noisy, art rock experimentalism that was a hallmark of their pre-Blur early days in the late 1980s as a indie artrock group [a=Seymour], only this time the music informed by a broader range of influences. Subsequent albums \"13\" and \"Think Tank\" further increased the group's distance from Britpop, eventually encompassing a great diversity of sounds and influences from all over the globe. On February 19, 2015, Blur made a surprise announcement that they'd finished a new album, \"The Magic Whip\", to be made available to the public on April 25, 2015, and also released a new song, \"Go Out\".\r\n\r\nNoteworthy live & session members:\r\n[a=Wayne Hernandez]: lead vocalist with backing choirs since 1997\r\n[a=Simon Tong]: guitarist; replaced Coxon for 2003–04 tour\r\n\r\nWhen marked as a copyright holder, use [l832168].",
+            "url_imagen": "https://i.discogs.com/zaSWN-jXaqklDF3x3tvl1TL2RcS8g9bSGvvDE90LRq0/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTc1NTEt/MTY4OTA2MTkxOS01/NjYzLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Fugazi - Fugazi",
+            "url_imagen": "https://i.discogs.com/4R2Cq9MKwuHqnVAWTano50St_QT_7K7gangQnNM0pO0/rs:fit/g:sm/q:90/h:603/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMzMTkx/OTAtMTQ0NTE2Mjc5/MC05OTg0LmpwZWc.jpeg",
+            "sello": "DISCHORD 30",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1988",
+            "estilos": "Alternative Rock, Hardcore, Punk, Post-Hardcore"
+        },
+        "tracklist": [
+            {
+                "nombre": "Waiting Room",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Bulldog Front",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Bad Mouth",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Burning",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Give Me The Cure",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Suggestion",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Glue Man",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Fugazi",
+            "nombre_real": "unasigned",
+            "perfil": "American punk rock band that formed in Washington, D.C. in 1987. The band consists of guitarists and vocalists Ian MacKaye and Guy Picciotto, bassist Joe Lally and drummer Brendan Canty. They are noted for their DIY ethic, manner of business practice, and contempt towards the music industry. The band has been on an indefinite break since 2003.",
+            "url_imagen": "https://i.discogs.com/Gp_XU1e9upE4u5ovSbfYxnVIOYGdag40a2YNzGzJuz0/rs:fit/g:sm/q:90/h:407/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTgyMTAz/LTExNDcxMDY3ODcu/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Iron Maiden - The Final Frontier",
+            "url_imagen": "https://i.discogs.com/rLmW_wvqK4zHU-CvOHDwk0LJekKy8RJ6pXbI9RTfT04/rs:fit/g:sm/q:90/h:606/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1OTMy/MDItMTQ0MjM1NTY3/OC05NzkyLmpwZWc.jpeg",
+            "sello": "50999 6477722 1",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "Europe",
+            "publicado": "2010",
+            "estilos": "Heavy Metal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Satellite 15...The Final Frontier",
+                "posicion": "1"
+            },
+            {
+                "nombre": "El Dorado",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Mother Of Mercy",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Coming Home",
+                "posicion": "4"
+            },
+            {
+                "nombre": "The Alchemist",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Isle Of Avalon",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Starblind",
+                "posicion": "7"
+            },
+            {
+                "nombre": "The Talisman",
+                "posicion": "8"
+            },
+            {
+                "nombre": "The Man Who Would Be King",
+                "posicion": "9"
+            },
+            {
+                "nombre": "When The Wild Wind Blows",
+                "posicion": "10"
+            }
+        ],
+        "artist": {
+            "nombre": "Iron Maiden",
+            "nombre_real": "unasigned",
+            "perfil": "English heavy metal band formed in Leyton, East London, in 1975 by bassist and primary songwriter [a=Steve Harris]. \r\n\r\n\r\nBand Members:\r\n\r\n[b]Vocals[/b]\r\n[a=Paul Mario Day] (1975-1976)\r\n[a=Dennis Willcock] (1976-1977)\r\n[a=Paul Di'Anno] (1978-1981)\r\n[a=Bruce Dickinson] (1981-1993 and 1999-present)\r\n[a=Blaze Bayley] (1994-1998)\r\n\r\n[b]Guitar[/b]\r\n[a=Terry Rance] (1975-1976)\r\nDave Sullivan (1975-1976)\r\n[a=Dave Murray (2)] (1976-1977 and 1978-present)\r\n[a=Bob Sawyer (3)] (1977)\r\n[a=Terry Wapram] (1977-1978)\r\n[a=Paul Cairns (2)] (1978-1979)\r\n[a=Paul Todd] (1979)\r\n[a=Tony Parsons (3)] (1979)\r\n[a=Dennis Stratton] (1979-1980)\r\n[a=Adrian Smith (2)] (1980-1990 and 1999-present)\r\n[a=Janick Gers] (1990-present)\r\n\r\n[b]Bass[/b]\r\n[a=Steve Harris] (1975-present)\r\n\r\n[b]Drums[/b]\r\n[a=Ron \"Rebel\" Matthews] (1975-1977)\r\nBarry \"[a=Thunderstick]\" Purkis (1977)\r\n[a=Doug Sampson] (1977-1979)\r\n[a=Clive Burr] (1980-1982)\r\n[a=Nicko McBrain] (1982-present)\r\n\r\n[b]Keyboards[/b] \r\n[a=Tony Hustings-Moore] (1977)\r\n[a=Michael Kenney] (1986-present) (Live performances only, not a full member)",
+            "url_imagen": "https://i.discogs.com/WJdyE5tiGWNcBF794ay1EUsSzzH_c0F-ctDg8hmLFgA/rs:fit/g:sm/q:90/h:587/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1MTU5/NS0xNjM4NTE1NTIz/LTkwNjYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Oscar Peterson Trio - Night Train",
+            "url_imagen": "https://i.discogs.com/UxY3OmRD9HoUSiGWCThIDxmeMuuYqTyFevKRpJBFZ9s/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwMzM4/OTgwLTE1OTMzNTQ0/ODMtNDM4NS5qcGVn.jpeg",
+            "sello": "V-8538",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1963"
+        },
+        "tracklist": [
+            {
+                "nombre": "Night Train",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "C Jam Blues",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Georgia On My Mind",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Bags' Groove",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Moten Swing",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Easy Does It",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Honey Dripper",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Things Ain't What They Used To Be",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "I Got It Bad And That Ain't Good",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Band Call",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Hymn To Freedom",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "The Oscar Peterson Trio",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/t8iVrhv1yjvimfo-49xNIoEoBBYkfgi27-IfxY2KjgE/rs:fit/g:sm/q:90/h:340/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1NTY0/Ni0xMzM2OTg1MDYz/LTcxNTYucG5n.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Chuck Mangione - Feels So Good",
+            "url_imagen": "https://i.discogs.com/-HxlDz9dz-sZJWOrtuysW9CVbIkBY2Etus9-C1YTqNo/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0ODIw/My0xNTkwNDQ4NzQx/LTYwNjYuanBlZw.jpeg",
+            "sello": "SP-4658",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1977",
+            "estilos": "Contemporary Jazz, Soul-Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "Feels So Good",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Maui-Waui",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Theme From \"Side Street\"",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Hide & Seek (Ready Or Not Here I Come)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Last Dance",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "The XIth Commandment",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Chuck Mangione",
+            "nombre_real": "unasigned",
+            "perfil": "American flugelhorn player and composer.\r\n\r\nBorn: 29 November 1940 in Rochester, New York, USA.\r\n\r\nBrother of pianist [a=Gap Mangione].",
+            "url_imagen": "https://i.discogs.com/eIlt1CA2K9xPfQA3filVbkACjLQY6XmLRDqBNVnPJWQ/rs:fit/g:sm/q:90/h:316/w:453/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTkyMDUx/LTE0NjU5NDc3ODgt/Njk1Mi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Miles Davis - Jack Johnson (Original Soundtrack Recording)",
+            "url_imagen": "https://i.discogs.com/qU180KbUGM4r8Qt8S39O2UvrmM8u9O2PoLPs1-l92pY/rs:fit/g:sm/q:90/h:614/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwNDcz/MTgtMTQwOTcwMzMy/Ni04Njk2LmpwZWc.jpeg",
+            "sello": "S 30455",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1971",
+            "estilos": "Jazz-Rock, Fusion"
+        },
+        "tracklist": [
+            {
+                "nombre": "Right Off",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Yesternow",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Miles Davis",
+            "nombre_real": "unasigned",
+            "perfil": "Trumpeter, bandleader, composer, and one of the most important figures in jazz music history, and music history in general. Davis adopted a variety of musical directions in a five-decade career that kept him at the forefront of many major stylistic developments in jazz. Winner of eight Grammy awards.\r\n\r\nBorn: 26 May 1926 in Alton, Illinois, USA.\r\nDied: 28 September 1991 in Santa Monica, California, USA (aged 65).\r\n\r\nBest known for his seminal modern jazz album \"[m=5460]\" (1959), the highest selling jazz album of all time with six million copies sold.\r\n\r\nMiles went to NYC to study at the academic school for musicians, where he met [a=Charlie Parker]. They started playing together from 1945. In 1948 Miles Davis started to make his own ensembles, at that time he met [a=Gil Evans], The Miles Davis Nonet was born. From the few recordings they made in 1949 to 1950 came the album \"[m=62308]\" (1957), with Davis and Evans going on to work more together in the future.\r\n\r\nMiles Davis was one of the musicians who introduced the 'Hard Bop' in the mid 1950s. In the late 1960s he started to experiment with electronic instruments and rock and funk rhythms. In the mid 1970s he stopped playing because of health problems, though in 1980 he made an 'electronical' comeback.\r\n\r\nInducted into Rock And Roll Hall of Fame in 2006 (Performer). Winner of Eight Grammy Awards.\r\n\r\nHe married dancer/actress [a=Frances Taylor Davis] on December 12, 1959; they divorced in 1968. He then married singer [a=Betty Mabry] in September 1968; they divorced in 1970. He then married actress [a=Cicely Tyson] on November 26, 1981; they divorced in 1989. Father of [a=Cheryl Davis] & [a=Erin Davis]. Uncle of [a=Vince Wilburn, Jr.]",
+            "url_imagen": "https://i.discogs.com/fvfSeynJ9rM5-55MQKikNuvvxxFpzVEcLZCls3-qRE0/rs:fit/g:sm/q:90/h:304/w:304/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIzNzU1/LTEzOTQzODczNDMt/NDUwMC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Bill Evans Trio* - Portrait In Jazz",
+            "url_imagen": "https://i.discogs.com/K3CbBVsR28dXD9CY_Cqdnuu39W9Qkb_GhUlK5ZiBd8Y/rs:fit/g:sm/q:90/h:603/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM1OTUz/MTEtMTY2ODAyNjU2/NS02MTE2LmpwZWc.jpeg",
+            "sello": "RLP 12-315",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1960",
+            "estilos": "Post Bop, Modal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Come Rain Or Come Shine",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Autumn Leaves",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Witchcraft",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "When I Fall In Love",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Peri's Scope",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "What Is This Thing Called Love?",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Spring Is Here",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Someday My Prince Will Come",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Blue In Green",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "The Bill Evans Trio",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/8rMdsQ-sOv6kgK5aUXprDd-CRNNeS6_r3_KHw_MbVpE/rs:fit/g:sm/q:90/h:535/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwMTE0/Ny0xNjM3NTQ5ODM5/LTM1MzEuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Bill Evans Trio* Featuring Scott La Faro* - Sunday At The Village Vanguard",
+            "url_imagen": "https://i.discogs.com/qzdI9vmF430nMwr3Ii2GrtYq800RzJgW9LJXD6LeSXY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEyNzY2/NTM5LTE1NDE1MzQ0/NTMtMzQ0MS5qcGVn.jpeg",
+            "sello": "RLP 376",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1961"
+        },
+        "tracklist": [
+            {
+                "nombre": "Gloria's Step",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "My Man's Gone Now",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Solar",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Alice In Wonderland",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "All Of You",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Jade Visions",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "The Bill Evans Trio",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/8rMdsQ-sOv6kgK5aUXprDd-CRNNeS6_r3_KHw_MbVpE/rs:fit/g:sm/q:90/h:535/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwMTE0/Ny0xNjM3NTQ5ODM5/LTM1MzEuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Miles Davis Quintet - Steamin' With The Miles Davis Quintet",
+            "url_imagen": "https://i.discogs.com/S369DLRrzQKQqfw17_2bqWOOKJBZS_Vve-_FH98FEZ0/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0ODgx/MzktMTI1MjQyNDA0/Mi5qcGVn.jpeg",
+            "sello": "7200",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1961",
+            "estilos": "Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Surrey With The Fringe On Top",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Salt Peanuts",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Something I Dreamed Last Night",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Diane",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Well You Needn't",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "When I Fall In Love",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "The Miles Davis Quintet",
+            "nombre_real": "unasigned",
+            "perfil": "The Miles Davis Quintet did not exist continously, but was formed several times with different basic line-ups. Mainly known are the two \"Great Quintets\".\r\n\r\n\"First Miles Davis Quintet\" or First Great Miles Davis Quintet\" - 1955 to 1958 with the following main artists (changes in line-up not shown here):\r\n    [a23755] — Trumpet\r\n    [a97545] — Tenor Saxophone\r\n    [a253641] — Piano\r\n    [a259778] — Double Bass\r\n    [a257251] — Drums\r\n    increased to Sextet in 1958 with [a61585] — Alto Saxophone \r\n\r\n\"Second Miles Davis Quintet\" or \"Second Great Miles Davis Quintet\" - 1964 to 1969 with the following main artists (changes in line-up not shown here):\r\n    [a23755] — Trumpet\r\n    [a29979] — Tenor Saxophone\r\n    [a3865] — Piano\r\n    [a95088] — Double Bass\r\n    [a261295] — Drums\r\n\r\nOutside these timespans there were also several Quintets besides the so called \"Great Quintets\". Several albums performed by the described Quintets are not credited to the group PAN, but to [a23755], please submit an \"Ensemble\" credit in these cases! (E.g. [r2882493])\r\n   ",
+            "url_imagen": "https://i.discogs.com/qtB0NTTCDDouLG2WfnI_f_eT48N0MleA1YUttVIXGHI/rs:fit/g:sm/q:90/h:336/w:444/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MjE1/Mi0xMzIyODE0NjU0/LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Incredible Jimmy Smith* - Back At The Chicken Shack",
+            "url_imagen": "https://i.discogs.com/OjMol0QYna52IPY4XBQRN3yTEZwobuNRLrGZ0Bd4QFI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIwMDU2/NDMtMTM1MjU3OTY0/Ny01MjAzLmpwZWc.jpeg",
+            "sello": "BLP 4117",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1963",
+            "estilos": "Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Back At The Chicken Shack",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "When I Grow Too Old To Dream",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Minor Chant",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Messy Bessie",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "Jimmy Smith",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz keyboardist, born 8 December 1928 in Norristown, Philadelphia, USA, died 8 February 2005 in Scottsdale, Arizona, USA (aged 76). He was married to [a313601]. Best known as a jazz musician who performed on the Hammond B-3 electric organ, which helped to popularize the instrument greatly. In 2005, Smith was awarded the NEA Jazz Masters Award from the National Endowment for the Arts, the highest honour that a US jazz musician can attain. \r\n\r\nFor the [l=Sun (9)] session pianist, see [a=Jimmy Smith (56)].",
+            "url_imagen": "https://i.discogs.com/b2QYLsHMEbcpEdB43h7wq3DZdkFzBUq9cuBfdXfSEnk/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI5OTgx/LTE0NTUzMzE2NTUt/NTE5OS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Weather Report - Sweetnighter",
+            "url_imagen": "https://i.discogs.com/hX-g76kpjzs_eMvI-y6fbBFrpsx-LdvbsiiKkTZjMNg/rs:fit/g:sm/q:90/h:622/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ4MTAw/MS0xNDQwNDQ1MjE4/LTc4MDMuanBlZw.jpeg",
+            "sello": "KC 32210",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1973",
+            "estilos": "Fusion, Contemporary Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "Boogie Woogie Waltz",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Manolete",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Adios",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "125th Street Congress",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Will",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Non-Stop Home",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Weather Report",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz fusion band with a career spanning between 1970 and 1986.",
+            "url_imagen": "https://i.discogs.com/D9UMqYOAQ4D71u_1IPSsnpc9RPv7BvkY7weWUri5zXE/rs:fit/g:sm/q:90/h:752/w:540/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwMDgy/LTE2NTYwNTczMjQt/Njg5NC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Miles Davis - Bags' Groove",
+            "url_imagen": "https://i.discogs.com/m9beINTfGrqMpOdvpjXgRlDvAg4GbMH--6iOAm9vpQs/rs:fit/g:sm/q:90/h:595/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIzMTE5/NzktMTU1NTAwNDY1/Ni04MjY4LmpwZWc.jpeg",
+            "sello": "7109",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1957",
+            "estilos": "Bop, Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Bags' Groove (Take 1)",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Bags' Groove (Take 2)",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Airegin",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Oleo",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "But Not For Me (Take 2)",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Doxy",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "But Not For Me (Take 1)",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Miles Davis",
+            "nombre_real": "unasigned",
+            "perfil": "Trumpeter, bandleader, composer, and one of the most important figures in jazz music history, and music history in general. Davis adopted a variety of musical directions in a five-decade career that kept him at the forefront of many major stylistic developments in jazz. Winner of eight Grammy awards.\r\n\r\nBorn: 26 May 1926 in Alton, Illinois, USA.\r\nDied: 28 September 1991 in Santa Monica, California, USA (aged 65).\r\n\r\nBest known for his seminal modern jazz album \"[m=5460]\" (1959), the highest selling jazz album of all time with six million copies sold.\r\n\r\nMiles went to NYC to study at the academic school for musicians, where he met [a=Charlie Parker]. They started playing together from 1945. In 1948 Miles Davis started to make his own ensembles, at that time he met [a=Gil Evans], The Miles Davis Nonet was born. From the few recordings they made in 1949 to 1950 came the album \"[m=62308]\" (1957), with Davis and Evans going on to work more together in the future.\r\n\r\nMiles Davis was one of the musicians who introduced the 'Hard Bop' in the mid 1950s. In the late 1960s he started to experiment with electronic instruments and rock and funk rhythms. In the mid 1970s he stopped playing because of health problems, though in 1980 he made an 'electronical' comeback.\r\n\r\nInducted into Rock And Roll Hall of Fame in 2006 (Performer). Winner of Eight Grammy Awards.\r\n\r\nHe married dancer/actress [a=Frances Taylor Davis] on December 12, 1959; they divorced in 1968. He then married singer [a=Betty Mabry] in September 1968; they divorced in 1970. He then married actress [a=Cicely Tyson] on November 26, 1981; they divorced in 1989. Father of [a=Cheryl Davis] & [a=Erin Davis]. Uncle of [a=Vince Wilburn, Jr.]",
+            "url_imagen": "https://i.discogs.com/fvfSeynJ9rM5-55MQKikNuvvxxFpzVEcLZCls3-qRE0/rs:fit/g:sm/q:90/h:304/w:304/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIzNzU1/LTEzOTQzODczNDMt/NDUwMC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Ramsey Lewis - Sun Goddess",
+            "url_imagen": "https://i.discogs.com/pmbpjmxn0Qjl5tLq-U28zVCst342zkb6LRtLyOUSV8w/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwMzY4/NC0xNjMyMDg5NTcz/LTYxNTMuanBlZw.jpeg",
+            "sello": "KC 33194",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1974",
+            "estilos": "Soul-Jazz, Jazz-Funk"
+        },
+        "tracklist": [
+            {
+                "nombre": "Sun Goddess",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Living For The City",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Love Song",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Jungle Strut",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Hot Dawgit",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Tambura",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Gemini Rising",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "Ramsey Lewis",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz pianist and keyboardist, born May 27, 1935 in Chicago, Illinois, USA, died September 12, 2022 in Chicago, Illinois, USA. ",
+            "url_imagen": "https://i.discogs.com/TMa35Ai0FvSqg2LdUJpG9xtfGruXnr_LptYOzIWTOR0/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU1NzM4/LTE1MDU3NDQ5OTgt/MzYyMC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "John Coltrane - Coltrane's Sound",
+            "url_imagen": "https://i.discogs.com/s85dlOK-IpiKFxCrn30xUuU66ta8OB_VPniLK9CJYWo/rs:fit/g:sm/q:90/h:614/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwMzcy/MDgtMTY3MTc3MjA3/Ny04MzIyLnBuZw.jpeg",
+            "sello": "SD 1419",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1964",
+            "estilos": "Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Night Has A Thousand Eyes",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Central Park West",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Liberia",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Body And Soul",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Equinox",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Satellite",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "John Coltrane",
+            "nombre_real": "unasigned",
+            "perfil": "American saxophonist and jazz composer.\r\n\r\nBorn: 23 September 1926 in Hamlet, North Carolina, USA.\r\nDied: 17 July 1967 in Huntington, Long Island, New York, USA (aged 40) from liver cancer.\r\n\r\nJohn Coltrane was one of the most influential musicians of the twentieth century. His early recordings capture a musician in the relatively conventional confines of bebop and hardbop, but his enduring legacy primarily rests on the modal jazz pioneered by his classic quartet (1960-64) and by free jazz explorations late in his career.\r\n\r\nHe recorded more than fifty albums as a leader and appeared as a sideman on many other albums, performing with other giants of jazz like [a=Miles Davis] and [a=Thelonious Monk]. Coltrane received numerous awards including a posthumous \"Special Citation\" from the Pulitzer Prize Board in 2007 for his 'masterful improvisation, supreme musicianship and iconic centrality to the history of jazz'.\r\n\r\nAs his life progressed, his music and outlook became increasingly spiritual. After his death he was proclaimed as a saint by the African Orthodox church that took his name.\r\n\r\nColtrane's second wife was pianist [a=Alice Coltrane]; their son [a=Ravi Coltrane] is also a saxophonist.",
+            "url_imagen": "https://i.discogs.com/HDV_XhHvZvJXYKExIG2mrJVZK717HAg5O9DwllCAYKs/rs:fit/g:sm/q:90/h:600/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3NTQ1/LTE0NTE0ODkwOTQt/Nzk1Mi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Chuck Mangione - Children Of Sanchez",
+            "url_imagen": "https://i.discogs.com/iE28cD1dUOEd8pz9pfyXOBANlpyXJhNwbsaI6xbZPxU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYyMjk4/MC0xMTk3MDA1MDI0/LmpwZWc.jpeg",
+            "sello": "SP-6700",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1978",
+            "estilos": "Soundtrack, Fusion, Smooth Jazz, Latin Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "Children Of Sanchez Overture",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Lullabye",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Fanfare",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Pilgrimage (Part 1)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Pilgrimage (Part 2)",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Consuelo's Love Theme",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Hot Consuelo",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Death Scene",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "Market Place",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "Echano",
+                "posicion": "C4"
+            },
+            {
+                "nombre": "Bellavia",
+                "posicion": "C5"
+            },
+            {
+                "nombre": "Lullabye",
+                "posicion": "C6"
+            },
+            {
+                "nombre": "Medley",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "B'bye",
+                "posicion": "D2"
+            },
+            {
+                "nombre": "Children Of Sanchez Finale",
+                "posicion": "D3"
+            }
+        ],
+        "artist": {
+            "nombre": "Chuck Mangione",
+            "nombre_real": "unasigned",
+            "perfil": "American flugelhorn player and composer.\r\n\r\nBorn: 29 November 1940 in Rochester, New York, USA.\r\n\r\nBrother of pianist [a=Gap Mangione].",
+            "url_imagen": "https://i.discogs.com/eIlt1CA2K9xPfQA3filVbkACjLQY6XmLRDqBNVnPJWQ/rs:fit/g:sm/q:90/h:316/w:453/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTkyMDUx/LTE0NjU5NDc3ODgt/Njk1Mi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Herbie Hancock - Mr. Hands",
+            "url_imagen": "https://i.discogs.com/9ji0MKupZRYBqqNDHUDknRXBTa96xxTD4UrAJOM22Ns/rs:fit/g:sm/q:90/h:594/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgzMjc0/MS0xNjUxNTE1NjA4/LTI1NDYuanBlZw.jpeg",
+            "sello": "JC 36578",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1980",
+            "estilos": "Fusion, Jazz-Funk"
+        },
+        "tracklist": [
+            {
+                "nombre": "Spiraling Prism",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Calypso",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Just Around The Corner",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "4 AM",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Shiftless Shuffle",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Textures",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Herbie Hancock",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz pianist, keyboardist, composer, band leader born April 12, 1940, in Chicago, Illinois, USA.\r\nHancock is one of the best-known modern jazz composers, creator of “Watermelon Man” (which has been a reference point throughout his career), “Maiden Voyage”, “Dolphin Dance”, right through to the dance grooves of “[r=3173760]”.",
+            "url_imagen": "https://i.discogs.com/FsPFfIQgWkq60J41ShsFZG0B0kBu0xAFIbo8kx_m9Ys/rs:fit/g:sm/q:90/h:350/w:414/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM4NjUt/MTEwNTk4NjY3Mi5q/cGc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Weather Report - Night Passage",
+            "url_imagen": "https://i.discogs.com/KsDE2CVQj9Ou49MqG4dtdbA9qQIw0GwgZGkLqGWATuI/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY4MTI1/MS0xNjg4MDYwNTQ5/LTU1ODcuanBlZw.jpeg",
+            "sello": "JC 36793",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1980",
+            "estilos": "Afro-Cuban Jazz, Fusion"
+        },
+        "tracklist": [
+            {
+                "nombre": "Night Passage",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Dream Clock",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Port Of Entry",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Forlorn",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Rockin' In Rhythm",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Fast City",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Three Views Of A Secret",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Madagascar",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "Weather Report",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz fusion band with a career spanning between 1970 and 1986.",
+            "url_imagen": "https://i.discogs.com/D9UMqYOAQ4D71u_1IPSsnpc9RPv7BvkY7weWUri5zXE/rs:fit/g:sm/q:90/h:752/w:540/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwMDgy/LTE2NTYwNTczMjQt/Njg5NC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Gabor Szabo - Dreams",
+            "url_imagen": "https://i.discogs.com/tUtG9oF0Xx-ZQEWw2vgD-oLiFiWdZGGEnXhDBPmtyqw/rs:fit/g:sm/q:90/h:616/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNDY2/NDctMTU2NTkwMDM1/My0xMjUzLmpwZWc.jpeg",
+            "sello": "SK-7",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1968",
+            "estilos": "Avant-garde Jazz, Soul-Jazz, Post Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Galatea's Guitar",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Half The Day Is Night",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Song Of The Injured Love",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "The Fortune Teller",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Fire Dance",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "The Lady In The Moon (From Kodaly)",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Ferris Wheel",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Gabor Szabo",
+            "nombre_real": "unasigned",
+            "perfil": "Hungarian jazz guitarist. \r\n\r\nBorn: 8 March 1936 in Budapest, Hungary. \r\nDied: 26 February 1982 in Budapest, Hungary (aged 45). \r\n\r\nAn influential jazz guitarist, famous for mixing jazz, pop-rock, and his native Hungarian music. Inspired by jazz music heard on Voice Of America radio broadcasts, Szabó began playing guitar at the age of 14. \r\n\r\nEscaping Hungary in 1956 and moving to the US where he attended the Berkeley School Of Music in Boston. In 1958, he was also invited to perform at the Newport Jazz Festival. Szabó then went on to perform with the quintet of southern California drummer [a=Chico Hamilton] from 1961 to 1965. \r\n\r\nBeginning in 1966, he recorded a well-received span of albums under his own name on the [l26557] label. In the late 1960s he co-founded the short-lived [l=Skye Records] label along with [a=Cal Tjader] and [a=Gary McFarland]. Later he signed with [l=Blue Thumb Records] and [l=CTI Records]. \r\n\r\nSzabó died in Budapest in 1982 from liver and kidney disease while on a visit to his homeland. \r\n",
+            "url_imagen": "https://i.discogs.com/6oS2Xp9JC0dXfo-z__oQShMwF6D4pxFJ79vS0QRHqTo/rs:fit/g:sm/q:90/h:416/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIyODUx/LTE2NDQ4NTA3MzIt/ODg3MS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Art Blakey & The Jazz Messengers - Indestructible",
+            "url_imagen": "https://i.discogs.com/lDKX8K1tk5HsK_nPhWEeIvTLoCiUhXlOVIpBlwKVxmc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1ODU5/MzUtMTMyNzM2MjY3/Ni5qcGVn.jpeg",
+            "sello": "BLP 4193",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1966",
+            "estilos": "Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Egyptian",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Sortie",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Calling Miss Khadija",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "When Love Is New",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Mr. Jin",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Art Blakey & The Jazz Messengers",
+            "nombre_real": "unasigned",
+            "perfil": "Archetypal hard-bop group of the late 1950s, most date their origin to 1954 or '55 when the first recordings credited to the band appeared.\r\nPlaying a driving, aggressive extension of bop with pronounced blues roots, the group continued until [url=http://www.discogs.com/artist/29977-Art-Blakey]Blakey[/url]'s death in 1990.\r\nThe name Jazz Messengers had been used by [a=Art Blakey] earlier, but when [a=Horace Silver] and [url=http://www.discogs.com/artist/29977-Art-Blakey]Blakey[/url]  began working together in the early 1950's the name had been dormant several years. The Jazz Messengers formed as a collective, nominally led by Silver or Blakey. Blakey credited Silver with reviving the Messengers name for the group. The original lineup of Blakey, Silver, [a=Hank Mobley], & [a=Kenny Dorham], was relatively shortlived. By late 1956 [a=Art Blakey] was the remaining original member.\r\nOver the years the Jazz Messengers served as a springboard for young jazz musicians, a proving ground for young jazz talent.",
+            "url_imagen": "https://i.discogs.com/pBilnAgQ5BkCMZglLOb--U1FV4TqAQCD2gJHphe5pPE/rs:fit/g:sm/q:90/h:286/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MjEy/OC0xMzMzNTUxMDQ4/LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Dave Brubeck Quartet - Gone With The Wind",
+            "url_imagen": "https://i.discogs.com/mu082zAI-EL6eiPk996Dm8MCudb4-xFhItXOFeyylUs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMwMTU3/MzYtMTQ1OTkzMjcy/Ny0zMjU0LmpwZWc.jpeg",
+            "sello": "CS 8156",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1959",
+            "estilos": "Cool Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "Swanee River",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "The Lonesome Road",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Georgia On My Mind",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Camptown Races",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Camptown Races",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Short'nin' Bread",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Basin Street Blues",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Ol' Man River",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Gone With The Wind",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "The Dave Brubeck Quartet",
+            "nombre_real": "unasigned",
+            "perfil": "The Dave Brubeck Quartet was a jazz quartet founded in 1951 by [a37737] on piano together with [a170329] on saxophone. The Dave Brubeck Quartet disbanded in 1967, and only met again for its 25th anniversary in 1976. The band name would later be used by the pianist for other groups that he led.",
+            "url_imagen": "https://i.discogs.com/XZItdZIdStC8w9NR-ciPBapvWd7rq-Ue-ZHml2sbcPo/rs:fit/g:sm/q:90/h:347/w:432/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1MTY4/OS0xMzk5NzA1NDk5/LTQ0MDYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Miles Davis - Miles Davis At Carnegie Hall",
+            "url_imagen": "https://i.discogs.com/OKi2lUL_nDJ_7HKJ1IaPP9EdQbtrKJUT1xTZQH7s2IQ/rs:fit/g:sm/q:90/h:400/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxNDA0/NzktMTQ2NDUyNjY2/Mi01NDQ5LmpwZWc.jpeg",
+            "sello": "CL 1812",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1962",
+            "estilos": "Hard Bop, Modal"
+        },
+        "tracklist": [
+            {
+                "nombre": "So What",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Spring Is Here",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "No Blues",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Oleo",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Someday My Prince Will Come",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "The Meaning Of The Blues / Lament / New Rhumba",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Miles Davis",
+            "nombre_real": "unasigned",
+            "perfil": "Trumpeter, bandleader, composer, and one of the most important figures in jazz music history, and music history in general. Davis adopted a variety of musical directions in a five-decade career that kept him at the forefront of many major stylistic developments in jazz. Winner of eight Grammy awards.\r\n\r\nBorn: 26 May 1926 in Alton, Illinois, USA.\r\nDied: 28 September 1991 in Santa Monica, California, USA (aged 65).\r\n\r\nBest known for his seminal modern jazz album \"[m=5460]\" (1959), the highest selling jazz album of all time with six million copies sold.\r\n\r\nMiles went to NYC to study at the academic school for musicians, where he met [a=Charlie Parker]. They started playing together from 1945. In 1948 Miles Davis started to make his own ensembles, at that time he met [a=Gil Evans], The Miles Davis Nonet was born. From the few recordings they made in 1949 to 1950 came the album \"[m=62308]\" (1957), with Davis and Evans going on to work more together in the future.\r\n\r\nMiles Davis was one of the musicians who introduced the 'Hard Bop' in the mid 1950s. In the late 1960s he started to experiment with electronic instruments and rock and funk rhythms. In the mid 1970s he stopped playing because of health problems, though in 1980 he made an 'electronical' comeback.\r\n\r\nInducted into Rock And Roll Hall of Fame in 2006 (Performer). Winner of Eight Grammy Awards.\r\n\r\nHe married dancer/actress [a=Frances Taylor Davis] on December 12, 1959; they divorced in 1968. He then married singer [a=Betty Mabry] in September 1968; they divorced in 1970. He then married actress [a=Cicely Tyson] on November 26, 1981; they divorced in 1989. Father of [a=Cheryl Davis] & [a=Erin Davis]. Uncle of [a=Vince Wilburn, Jr.]",
+            "url_imagen": "https://i.discogs.com/fvfSeynJ9rM5-55MQKikNuvvxxFpzVEcLZCls3-qRE0/rs:fit/g:sm/q:90/h:304/w:304/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIzNzU1/LTEzOTQzODczNDMt/NDUwMC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Stan Getz – Joao Gilberto* - Getz / Gilberto #2",
+            "url_imagen": "https://i.discogs.com/DSOGuRE8J-XYIUnKlr1UFLZVa-wc-eo4i_8mNRWfW3Q/rs:fit/g:sm/q:90/h:536/w:547/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUzNjcx/MjAtMTM5MTY0Njkz/MS0xNzgxLmpwZWc.jpeg",
+            "sello": "V/8623",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1966",
+            "estilos": "Swing, Bop, Latin Jazz, Bossa Nova"
+        },
+        "tracklist": [
+            {
+                "nombre": "Grandfather's Waltz",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Tonight I Shall Sleep With A Smile On My Face",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Stan's Blues",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Here's That Rainy Day",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Samba Da Minha Terra",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Rosa Moreno",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Um Abraco No Bonfa",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Bim Bom",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Meditation",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "O Pato (The Duck)",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Stan Getz",
+            "nombre_real": "unasigned",
+            "perfil": "Jazz saxophonist, born February 2, 1927, Philadelphia, Pennsylvania, USA - died June 6, 1991, Malibu, California, USA.",
+            "url_imagen": "https://i.discogs.com/RLwcssrTkzgtnFGN0cZwKcrND1FplpFQWwDazAeISMA/rs:fit/g:sm/q:90/h:456/w:457/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwNDg2/LTE2NTg5NDY0ODct/NTI1My5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Yusef Lateef - Eastern Sounds",
+            "url_imagen": "https://i.discogs.com/kquBiQTIn4YtMwmtW3w26h9j7wRXQSWyz8vxB2q3WBk/rs:fit/g:sm/q:90/h:598/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4MTUy/NzctMTU2NzYwNzMx/MC01OTQ3LmpwZWc.jpeg",
+            "sello": "MV 22",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1961",
+            "estilos": "Post Bop, Modal"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Plum Blossom",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Blues For The Orient",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Ching Miau",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Don't Blame Me",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Love Theme From Spartacus",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Snafu",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Purple Flower",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Love Theme From The Robe",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Three Faces Of Balal",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Yusef Lateef",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz musician, artist, composer, and producer. \r\n\r\nBorn: 9 October 1920 in Chattanooga, Tennessee, USA. \r\nDied: 23 December 2013 in Amherst, Massachusetts, USA (aged 93). \r\n\r\nLateef was a jazz multi-instrumentalist, composer and prominent figure among the Ahmadiyya Muslim Community in America, following his conversion to Islam in 1950. Although Lateef's main instruments were the tenor saxophone and flute, he also played oboe and bassoon, both rare in jazz, and also used a number of non-western instruments such as the bamboo flute, shanai, shofar, xun, arghul and koto. \r\n\r\nLateef had an inquisitive spirit and was never just a bop or hard bop soloist. He did not care much for the term \"jazz\", consistently creating music that stretched (and even broken through) boundaries. A superior tenor saxophonist with a soulful sound and impressive technique, by the 1950s Lateef was one of the top flutists around. He also developed into a talented jazz soloist on the oboe, was an occasional bassoonist, and introduced such instruments as the arghul (a double clarinet that resembles a bassoon), shanai (a type of oboe), and different types of flutes. \r\n\r\nLateef played \"world music\" long before the term was coined. \r\n",
+            "url_imagen": "https://i.discogs.com/QoRUP0w_KcfTmRCJu7ADicOCxF8TgVIccTR8pDyA4po/rs:fit/g:sm/q:90/h:530/w:438/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE2NzA1/NS0xNTg0NjI0NTU4/LTcyODQuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Fleetwood Mac - Mr. Wonderful",
+            "url_imagen": "https://i.discogs.com/48f4TAFxy7kVib01pfsUHDy2ki2Ixa_Xuvxu3MfSsaw/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4NTg0/ODAtMTU0OTYxNDUy/MS0xNDk3LmpwZWc.jpeg",
+            "sello": "7-63205",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "UK",
+            "publicado": "1968",
+            "estilos": "Rhythm & Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Stop Messin' Round",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "I've Lost My Baby",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Rollin' Man",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Dust My Broom",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Love That Burns",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Doctor Brown",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Need Your Love Tonight",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "If You Be My Baby",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Evenin' Boogie",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Lazy Poker Blues",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Coming Home",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Trying So Hard To Forget",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Fleetwood Mac",
+            "nombre_real": "unasigned",
+            "perfil": "Founded in London in July 1967 (by ex-[url=http://www.discogs.com/artist/John+Mayall+%26+The+Bluesbreakers]Bluesbreakers[/url] members, Peter Green and Mick Fleetwood), \"Peter Green's Fleetwood Mac\" instantly became a major force in the UK blues scene, along with their eponymous first album. Following \"Mr. Wonderful\" & \"Then Play On\" the driving force of Peter Green had deteriorated as he lapsed into a personal crisis by 1970. The group reorganized, under the leadership of Fleetwood, and slowly took on a new direction - away from the blues and into the mainstream of international popularity, known simply as [b]Fleetwood Mac[/b].\r\n\r\nMember/Dates:\r\nPeter Green (guitar, vocals, 1967-70)\r\nMick Fleetwood (drums, 1967-1995, 1997-present)\r\nJohn McVie (bass, 1967-1995, 1997-present)\r\nJeremy Spencer (guitar, vocals, 1967-71)\r\nBob Brunning (bass, 1967)\r\nDanny Kirwan (guitar, 1968-72)\r\nChristine McVie (vocals, piano, accordion, 1970-1995, 1997-1998, 2014-2022)\r\nBob Welch (guitar, vocals, 1971-74)\r\nBob Weston (guitar, 1973-74)\r\nDave Walker (guitar, vocals, 1973)\r\nDoug Graves (keyboards, 1974)\r\nLindsey Buckingham (guitar, vocals, piano, 1975-87, 1993, 1997-2018)\r\nStevie Nicks (vocals, 1974–1991, 1993, 1997-present)\r\nBilly Burnette (guitar, vocals, 1990-94)\r\nRick Vito (guitar, 1990-91)\r\nDave Mason, (guitar, vocals, 1993-94)\r\nBekka Bramlett (vocals, 1993-94)\r\nMike Campbell (lead guitar, vocals, 2018–present)\r\nNeil Finn, (vocals, rhythm guitar, 2018–present)\r\n\r\nInducted into Rock And Roll Hall of Fame in 1998 (Performer)",
+            "url_imagen": "https://i.discogs.com/RmgxJXQV5jyibCGHQHnmKq3JsRWkhHE1P3t9rj_7O8E/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ3MzMz/LTE1NjY1NjE1NTIt/MjgxMS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Johnny Winter - Nothin' But The Blues",
+            "url_imagen": "https://i.discogs.com/l6-GOXpLj5Fvrgi8cZtkBxChjaz4YP4_DgXXRdER7ZE/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0Njcy/MS0xMzY2NzkyMjc3/LTMzOTIuanBlZw.jpeg",
+            "sello": "PZ 34813",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1977",
+            "estilos": "Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Tired Of Tryin'",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "TV Mama",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Sweet Love And Evil Women",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Everybody's Blues",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Drinkin' Blues",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Mad Blues",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "It Was Rainin'",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Bladie Mae",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Walking Thru The Park",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "Johnny Winter",
+            "nombre_real": "unasigned",
+            "perfil": "American blues guitarist and singer (born February 23, 1944 in Beaumont, Texas USA - died July 16, 2014 in Zurich, Switzerland).\r\n\r\nHis first instruments were the clarinet and the ukulele, settling on guitar by age eleven. Something of a musical child prodigy, he grew up in Beaumont, Texas, on a diet of blues and rock 'n' roll. As a teen, nearly every weekend he would hitch-hike to Louisiana to play in small night clubs. After a short college stint, he gave up his academic pursuits and devoted himself to creating music.\r\nHe signed a five year contract with Columbia Records in 1969 (for $300,000) and the rest is history. Before signing to Columbia he recorded one album (two if you consider 'First Winter' als a proper album) and lots of singles, under his own name or as sideman. These have been repackaged and compiled at infinite.\r\n\r\nOlder brother of [a=Edgar Winter].\r\n",
+            "url_imagen": "https://i.discogs.com/wxS2Sja1WPrdj5UM4TAWmtXZNec-AXgH7FwIZarOoMw/rs:fit/g:sm/q:90/h:448/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1NDE5/OC0xNDU4NDkxNTg4/LTg3MTUuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "George Thorogood And The Destroyers* - Better Than The Rest",
+            "url_imagen": "https://i.discogs.com/h0iWlw0HXUMW3BB-ytHZ2hvldrYbaWlGlRSDnoAXKrE/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTg2NDUz/Ni0xNTk4OTY3ODk5/LTMyMjQuanBlZw.jpeg",
+            "sello": "MCA-3091",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1979",
+            "estilos": "Modern Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "In The Night Time",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "I'm Ready",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Goodbye Baby",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Howlin' For My Darlin'",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "My Weakness",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Nadine",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "My Way",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "You're Gonna Miss Me",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Worried About My Baby",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Huckle Up Baby",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "George Thorogood & The Destroyers",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/Kxwq57R-qE63mx-F0-qt9OyWvEzikgOLhryUKBxL3d4/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1ODEy/MC0xNTAzNDI5ODYx/LTE4NzAuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "R.L. Burnside - Too Bad Jim",
+            "url_imagen": "https://i.discogs.com/04sB6PeZPFcMVurf3_uufXURY5RCVyqrkxoYCoVxwJs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEzMTEy/MDM4LTE2MjU2MzE2/NDYtNTc3OC5qcGVn.jpeg",
+            "sello": "80307-1",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1994",
+            "estilos": "Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Shake 'Em On Down",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "When My First Wife Left Me",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Short-Haired Woman",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Old Black Mattie",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Fireman Ring The Bell",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Peaches",
+                "posicion": "B6"
+            },
+            {
+                "nombre": "Miss Glory B.",
+                "posicion": "B7"
+            },
+            {
+                "nombre": ".44 Pistol",
+                "posicion": "B8"
+            },
+            {
+                "nombre": "Death Bell Blues",
+                "posicion": "B9"
+            },
+            {
+                "nombre": "Goin' Down South",
+                "posicion": "B10"
+            }
+        ],
+        "artist": {
+            "nombre": "R.L. Burnside",
+            "nombre_real": "unasigned",
+            "perfil": "Born: November 21, 1926, either Harmontown, College Hill or Blackwater Creek all of which are in the rural part of Lafayette County, Mississippi\r\nDied: September 1, 2005, Memphis, Tennessee; buried at Free Springs Cemetery in Harmontown, MS.\r\n\r\nHis first name is given as R.L., Rural (which is on his tombstone), Robert Lee, Rule, or Ruel.  His father left him early on and he grew up in his large family including his mother, grandparents and several siblings.  Started playing harmonica and guitar at age 16 learning from Mississippi Fred McDowelll.  R.L. credited Muddy Waters, Lightnin' Hopkins and John Lee Hooker as influences.  Muddy Waters was his cousin-in-law.  While living in Chicago in the late-1940's his father and two uncles were murdered in the same year which he sang about and referenced often in his songs.  He returned to Mississippi and working through the 1980's as a sharecropper and a commercial fisherman selling what he caught door-to-door.  He started to receive recognition in the 1990's.\r\n\r\nFather of [a4801571]\r\nFather-in-law of [a2018914]\r\nGrandfather of [a384455]",
+            "url_imagen": "https://i.discogs.com/cCa7kvrmzsXrkyxBW9mEvJ0HwBTmyqiOy_ZlUnvnZmQ/rs:fit/g:sm/q:90/h:831/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2Mjkw/MS0xNjE4NTk1NTE3/LTcxNDQucG5n.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "B.B. King - L.A. Midnight",
+            "url_imagen": "https://i.discogs.com/EdaMN49TskpYdJ7eOqTzCWtic5lEtUjGOFctQicO8AA/rs:fit/g:sm/q:90/h:470/w:450/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4OTI1/NTMtMTQxMTQ4ODAz/MS04MzUxLmpwZWc.jpeg",
+            "sello": "SPB 1051",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "UK",
+            "publicado": "1972"
+        },
+        "tracklist": [
+            {
+                "nombre": "I Got Some Help I Don't Need",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Help The Poor",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Can't You Hear Me Talking To You",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Midnight",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Sweet Sixteen",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "(I Believe) I've Been Blue Too Long",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Lucille's Granny",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "B.B. King",
+            "nombre_real": "unasigned",
+            "perfil": "American blues singer, guitarist, and songwriter (September 16, 1925 near Itta Bena, Mississippi - May 14, 2015, Las Vegas, Nevada). \r\nB.B. is an abbreviation for 'Blues Boy'.\r\n\r\nKing is one of the most influential blues musicians of all time, earning the nickname \"The King of the Blues.\" He is considered one of the \"Three Kings of the Blues Guitar\" (along with [a=Albert King] and [a=Freddie King], none of whom are related). Since he started recording in the 1940s, he released over fifty albums. He previously worked as a tractor driver.\r\n\r\nIn his youth, he played on street corners for dimes, and would sometimes play in as many as four towns a night. In 1947, he hitchhiked to Memphis, TN, to pursue his music career. In Memphis, B.B. stayed with his cousin [a=Bukka White], one of the most celebrated blues performers of his time, who B.B. credits as one of his earliest mentors and teachers. King's first big break came in 1948 when he performed on [a=Sonny Boy Williamson]’s radio program on KWEM out of West Memphis. This radio performance led to steady engagements at the Sixteenth Avenue Grill in West Memphis and later to a ten-minute spot on the Memphis radio station WDIA. King's radio spot become so popular, it was expanded and became the “Sepia Swing Club.” As King worked at WDIA as a singer and disc jockey, he was given the catchy radio nickname \"Beale Street Blues Boy\", later shortened to \"Blues Boy\", and finally to \"B.B.\" \r\n\r\nIn the late 1940s and early 1950s, King was a part of the blues scene on Beale Street. \"Beale Street was where it all started for me\", King said. He performed with [a=Bobby Bland], [a=Johnny Ace], and [a=Earl Forest] in a group known as [a=The Beale Streeters]. In 1949, King made his recording debut on [l=Bullet (2)] ([l=Bullet Recording & Transcription Co.]) by issuing the single [url=https://www.discogs.com/release/7031392-BB-King-Miss-Martha-King-When-Your-Baby-Packs-Up-And-Goes]\"Miss Martha King\"[/url], which did not chart well. Later that year, he began a recording contract with Los Angeles-based [l=RPM Records (5)]. Many of King's early recordings were produced by [a=Sam Phillips (2)] (who later founded [l=Sun Record Company]). King's recording contract was followed by tours across the US, with performances in big city theatres as well as gigs in small clubs and juke joints in the southern United States. During one show in Twist, Arkansas, a fight broke out between two men and caused a fire. King evacuated with the rest of the crowd, but realizing he left his acoustic guitar inside, rushed back inside the burning building to retrieve it. He later discovered the two men were fighting over a woman named Lucille. Ever since, each one of B.B.’s trademark Gibson guitars has been called Lucille, as a reminder not to fight over women or run into any more burning buildings. \r\n\r\nIn 1952, B.B. had a number one hit with “Three O’Clock Blues,” and began touring nationally soon after. 1956 became a record-breaking year, with 342 concerts booked and three recording sessions. That same year he founded his own record label, [l=Blues Boys Kingdom], with headquarters at Beale Street in Memphis. In 1962, King signed to [l=ABC-Paramount] Records, which was later absorbed into [l=MCA Records]. In November 1964, King recorded the [m=107099] album, considered to be one of his finest recordings. In 1968, B.B. played at the [l=Newport Folk Festival] and at [a=Bill Graham (2)]’s [l=Fillmore West] on bills with the hottest contemporary rock artists of the day who idolized B.B. and helped to introduce him to a young white audience. In 1969, B.B. was chosen by [a=The Rolling Stones] as the opening act for their American tour. He won a 1970 Grammy Award for his version of the song \"The Thrill Is Gone\", which was a hit on both the Pop and R&B charts. It also gained the number 183 spot in Rolling Stone magazine's 500 Greatest Songs of All Time. From the 1980s until his death in 2015, he maintained a highly visible and active career, appearing on numerous television shows and performing as much as 300 nights a year.\r\n\r\nB.B. was inducted into the Blues Foundation Hall of Fame in 1984 and into the Rock And Roll Hall of Fame in 1987 (Performer).",
+            "url_imagen": "https://i.discogs.com/xV3Pd56I0RSs6P9ZS2SUz65Vuz8AxJU9HsiuMNDNbU0/rs:fit/g:sm/q:90/h:632/w:521/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM3NzI5/LTEzMjg2MTE0Nzku/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "John Lee Hooker - That's My Story: John Lee Hooker Sings The Blues",
+            "url_imagen": "https://i.discogs.com/Bb83qA6P9m8rJSboc9poPyP0YP0vs_bJ3k6HCzymC78/rs:fit/g:sm/q:90/h:391/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ1NTQx/NzMtMTM2ODIwNTE2/Ni04MjIwLmpwZWc.jpeg",
+            "sello": "12-321",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1960",
+            "estilos": "Delta Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "I Need Some Money ",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Come On And See About Me ",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "I'm Wanderin' ",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Democrat Man ",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "I Want To Talk About You ",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Gonna Use My Rod ",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Wednesday Evenin' Blues ",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "No More Doggin' ",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "One Of These Days ",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "I Believe I'll Go Back Home ",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "You're Leavin' Me, Baby ",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "That's My Story ",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "John Lee Hooker",
+            "nombre_real": "unasigned",
+            "perfil": "American blues singer-songwriter and guitarist.\r\nBorn: August 22, 1912 in Tutwiler, Tallahatchie County, Mississippi, USA.\r\nDied: June 21, 2001 in Los Altos, California, USA.\r\n\r\nSome of his best known songs include \"Boogie Chillen'\" (1948), \"Crawling King Snake\" (1949), \"Dimples\" (1956), \"Boom Boom\" (1962), and \"One Bourbon, One Scotch, One Beer\" (1966). Several of his later albums, including The Healer (1989), Mr. Lucky (1991), Chill Out (1995), and Don't Look Back (1997), were album chart successes in the U.S. and UK.\r\n\r\nInducted into Rock And Roll Hall of Fame in 1991 (Performer).",
+            "url_imagen": "https://i.discogs.com/LsQ3wwUAxYVkj0X2KkLCi4FbABhPdskItIza2FpbFXg/rs:fit/g:sm/q:90/h:583/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk0NTU3/LTE1ODIxMzE5MDYt/NDcwMi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Robert Johnson - The Complete Collection",
+            "url_imagen": "https://i.discogs.com/LU2WXZAvpS46NIkwLTx7ZMdUUQic4brdnjPneyrj_EI/rs:fit/g:sm/q:90/h:518/w:519/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5NzMw/MjktMTI1NTk3ODUz/MS5qcGVn.jpeg",
+            "sello": "PLATCD 278",
+            "formato": "CD",
+            "genero": "Blues",
+            "pais": "UK",
+            "publicado": "unassigned",
+            "estilos": "Delta Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "I Believe I'll Dust My Broom",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Phonograph Blues",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Ramblin' On My Mind",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Kindhearted Woman Blues",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Terraplane Blues",
+                "posicion": "5"
+            },
+            {
+                "nombre": "I'm A Steady Rollin' Man",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Walking Blues",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Last Fair Deal Gone Down",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Dead Shrimp Blues",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Sweet Home Chicago",
+                "posicion": "10"
+            },
+            {
+                "nombre": "32-20 Blues",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Come On In My Kitchen",
+                "posicion": "12"
+            },
+            {
+                "nombre": "If I Had Possession Over Judgement Day",
+                "posicion": "13"
+            },
+            {
+                "nombre": "Me And The Devil Blues",
+                "posicion": "14"
+            },
+            {
+                "nombre": "Preaching Blues (Up Jumped The Devil)",
+                "posicion": "15"
+            },
+            {
+                "nombre": "Stones In My Passway",
+                "posicion": "16"
+            },
+            {
+                "nombre": "Cross Road Blues",
+                "posicion": "17"
+            },
+            {
+                "nombre": "Travelling Riverside Blues",
+                "posicion": "18"
+            },
+            {
+                "nombre": "When You Got A Good Friend",
+                "posicion": "19"
+            },
+            {
+                "nombre": "Milkcow's Calf Blues",
+                "posicion": "20"
+            },
+            {
+                "nombre": "Hellhound On My Trail",
+                "posicion": "21"
+            },
+            {
+                "nombre": "From Four 'Til Late",
+                "posicion": "22"
+            },
+            {
+                "nombre": "Honeymoon Blues",
+                "posicion": "23"
+            },
+            {
+                "nombre": "Stop Breakin' Down Blues",
+                "posicion": "24"
+            },
+            {
+                "nombre": "Malted Milk",
+                "posicion": "25"
+            },
+            {
+                "nombre": "Little Queen Of Spades",
+                "posicion": "26"
+            },
+            {
+                "nombre": "They're Red Hot",
+                "posicion": "27"
+            },
+            {
+                "nombre": "Drunken Hearted Man",
+                "posicion": "28"
+            },
+            {
+                "nombre": "Love In Vain",
+                "posicion": "29"
+            }
+        ],
+        "artist": {
+            "nombre": "Robert Johnson",
+            "nombre_real": "unasigned",
+            "perfil": "Legendary, influential delta blues guitarist, singer and songwriter.\r\nBorn: May 8, 1911, Hazlehurst, Mississippi\r\nDied: August 16, 1938, Greenwood, Mississippi\r\n\r\nPassed away at 27, leaving a widespread impact on music. Some of his songs have been credited to [a=Woody Payne (2)], also known as [a=T Colley]. Inducted into Rock And Roll Hall of Fame in 1986 (Early Influence).\r\n\r\nFather of [a13326465].\r\n\r\n[b]Note: For the [a=KC & The Sunshine Band] drummer, please use [a=Robert Johnson (3)].\r\nFor the English composer from the Renaissance, please use [a=Robert Johnson (9)].[/b]",
+            "url_imagen": "https://i.discogs.com/SpYMW7uZMm0VHveoIDozXzBFdzwV0F9_-gt38cqhc0E/rs:fit/g:sm/q:90/h:800/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI3MjE0/Mi0xNTkyODQwMTUz/LTMzMzMucG5n.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Freddie King - My Feeling For The Blues",
+            "url_imagen": "https://i.discogs.com/qVvEWmhgq7Q26i6Xu-suIe-9HDFDILZFnewyrncO6OA/rs:fit/g:sm/q:90/h:413/w:399/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMwNTcz/OTQtMTM0MDIwMTcy/My00NDEyLmpwZWc.jpeg",
+            "sello": "SD 9016",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1970",
+            "estilos": "Rhythm & Blues, Texas Blues, Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Yonder Wall",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Stumble",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "I Wonder Why",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Stormy Monday",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "I Don't Know",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "What'd I Say",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Ain't  Nobody's Business What We Do",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "You Don't Have To Go",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Woke Up This Morning",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Things I Used To Do",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "My Feeling For The Blues",
+                "posicion": "b6"
+            }
+        ],
+        "artist": {
+            "nombre": "Freddie King",
+            "nombre_real": "unasigned",
+            "perfil": "American blues guitarist and singer.\r\nBorn September 3, 1934 in Gilmer, Texas, died December 28, 1976 in Dallas, Texas. \r\nHe moved to Chicago, Illinois, in 1949. In 1956 he cut his first record as a leader. Later he was one of the first bluesmen to have a multi-racial backing band at live performances. Freddie King is often mentioned as one of “the three kings” of electric blues guitar along with Albert King and B.B. King (no relation).\r\nIn 1993 by proclamation from the Texas Governor Ann Richards,  September 3 was declared the Freddie King Day. Freddie King placed 15th in Rolling Stone magazine’s list of the 100 greatest guitarists of all time. In 2012, he was inducted into the Rock and Roll Hall of Fame.",
+            "url_imagen": "https://i.discogs.com/F18h5ZX1HSYQL0v5LK_7yXrWBaJyPfqY8lLiqkD-qRU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMyMzE2/Mi0xNTI5NzY2OTk1/LTU2NDAucG5n.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Hound Dog Taylor And The HouseRockers* - Natural Boogie",
+            "url_imagen": "https://i.discogs.com/ohBSfGnxFUqPnZjZjF2UGfAYTfhaq7Vms86XCq8A550/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE2MjIz/MTAtMTM4NTY2MTM0/NC0yNzEyLmpwZWc.jpeg",
+            "sello": "AL 4704",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1974",
+            "estilos": "Electric Blues, Chicago Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Take Five",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Hawaiian Boogie",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "See Me In The Evening",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "You Can't Sit Down",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Sitting At Home Alone",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "One More Time",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Roll Your Moneymaker",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Buster's Boogie",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Sadie",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Talk To My Baby",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Goodnight Boogie",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Hound Dog Taylor & The House Rockers",
+            "nombre_real": "unasigned",
+            "perfil": "Hound Dog's band.\r\nMembers:\r\nHound Dog Taylor - Lead & Slide Guitar and Vocals\r\nBrewer Phillips - Second Guitar\r\nTed Harvey - Drums\r\n",
+            "url_imagen": "https://i.discogs.com/Wp-4zW1z8TLlkAC3bvmHoLWZEaGxqSTmqUMaiUjGV70/rs:fit/g:sm/q:90/h:563/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ4OTY2/My0xMzczODk1OTI5/LTIyNDcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Various - The Blues World Of Eric Clapton",
+            "url_imagen": "https://i.discogs.com/etSEb23EAhU1wsi2jr7NAaEqMF47qe9SwmWTiG4tx2U/rs:fit/g:sm/q:90/h:500/w:491/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxNzMy/NDItMTQxMjg4ODY5/MS0zMjU1LmpwZWc.jpeg",
+            "sello": "SPAI 387",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "UK",
+            "publicado": "1975"
+        },
+        "tracklist": [
+            {
+                "nombre": "Steppin' Out",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Calcutta Blues",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Lonely Years",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "They Call It Stormy Monday",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Shim-Sham-Shimmy",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Ramblin' On My Mind",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Pretty Girls Everywhere",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Hideaway",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Key To Love",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Bernard Jenkins",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Third Degree",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Have You Heard",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Hound Dog Taylor & The House Rockers",
+            "nombre_real": "unasigned",
+            "perfil": "Hound Dog's band.\r\nMembers:\r\nHound Dog Taylor - Lead & Slide Guitar and Vocals\r\nBrewer Phillips - Second Guitar\r\nTed Harvey - Drums\r\n",
+            "url_imagen": "https://i.discogs.com/Wp-4zW1z8TLlkAC3bvmHoLWZEaGxqSTmqUMaiUjGV70/rs:fit/g:sm/q:90/h:563/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ4OTY2/My0xMzczODk1OTI5/LTIyNDcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Buddy Guy - The Blues Giant",
+            "url_imagen": "https://i.discogs.com/Xy44-g8Ex-7u1VMHwWyQsvB-HS-5xex60AiE8RaYwzE/rs:fit/g:sm/q:90/h:593/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc3OTIz/Ni0xNjUyMDkxNjky/LTM2MzYuanBlZw.jpeg",
+            "sello": "900.500",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "France",
+            "publicado": "1980",
+            "estilos": "Chicago Blues, Modern Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "I Smell A Rat",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Are You Losing In Your Mind",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "You've Been Gone Too Long",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "She Is Out There",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Outskirts Of Town",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "When I Left Home",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "nombre": "Buddy Guy",
+            "nombre_real": "unasigned",
+            "perfil": "American blues guitarist and singer, born July 30th, 1936 in Lettsworth, Louisiana, and one of the pioneers of the Chicago blues sound. Began performing with bands in Baton Rouge in the '50s before moving to Chicago in 1957. He originally recorded for [l=Cobra Record Corp.] subsidiary [l=Artistic (2)] before moving to [l=Chess], where he worked as a sideman and leader when Cobra folded. During his time on Chess he also recorded under the pseudonym Friendly Chap for [l=Delmark Records]. He moved to [l=Vanguard] in 1967, and then went on to work with a variety of labels. He is the brother of [a=Phil Guy].\r\n\r\nGuy has won six Grammy awards, 23 W.C. Handy Awards, and, in 2003, he was awarded the National Medal of Arts. He was inducted into the Rock And Roll Hall of Fame in 2005, and into the Louisiana Music Hall of Fame in 2008.",
+            "url_imagen": "https://i.discogs.com/Xxu5FihWR65mxdt1rWl3q8xDm2cPSXKHFxmhtyCeWpI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1OTc5/OS0xNjU3Mzk3NjAw/LTE0OTcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Muddy Waters - The Real Folk Blues",
+            "url_imagen": "https://i.discogs.com/qbW8ckFeBzHJzyYSDdwH0ChaPVdvi0hiXNxcoO0ZRKk/rs:fit/g:sm/q:90/h:559/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY5Njc3/MzEtMTQzMDYxNzc1/NS01MzY4LmpwZWc.jpeg",
+            "sello": "LP-1501",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1966"
+        },
+        "tracklist": [
+            {
+                "nombre": "Mannish Boy",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Screaming And Crying",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Just To Be With You",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Walking In The Park",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Walking Blues",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Canary Bird",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Same Thing",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Gypsy Woman",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Rollin' & Tumblin'",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "40 Days & 40 Nights",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Little Geneva",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "You Can't Lose What You Never Had",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Muddy Waters",
+            "nombre_real": "unasigned",
+            "perfil": "American blues guitarist, singer and composer.\r\nBorn 4 April 1913, Rolling Fork, Mississippi, USA.\r\nDied 30 April 1983, Westmont, Illinois, USA.\r\n\r\nFather of [a4092559], [a1965346], and [a10232473] (died December 10, 2020, aged 56).\r\n\r\nConsidered by many to be a founder of the modern Chicago Blues style. A powerful inspiration in the emergence of the electric blues-oriented groups in the UK during the '60s. He became the most prominent interpreter of the electric blues.\r\n\r\nOn Morganfield's marriage license and Musician's Union card, he indicates the year of his birth as 1913. His place of birth was, in fact, in Issaquena County near Rolling Fork, Mississippi. However, his gravestone remains dated as 1915.\r\n\r\nMorganfield was inducted into the 'Rock And Roll Hall of Fame' in 1987 (Performer).",
+            "url_imagen": "https://i.discogs.com/zXjNo-YVgICr_M2uGoqa-RwvYRlCvJAlkMukALLhLo8/rs:fit/g:sm/q:90/h:306/w:306/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU5MjQ2/LTEzOTQ5ODU2NTMt/NDExMS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Howling Wolf* - Howling Wolf Sings The Blues",
+            "url_imagen": "https://i.discogs.com/FIbxiwqDE5g4sHjN4SGJKCQ21dR58iLEAMHJ9YKRFgs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM2OTI3/ODQtMTQ1MTA3NTE4/Mi00NDI3LmpwZWc.jpeg",
+            "sello": "CLP 5240",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1962",
+            "estilos": "Delta Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Riding In The Moonlight",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Worried About My Baby ",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Crying At Daylight",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Brown Skin Woman",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Twisting And Turning",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "House Rockin' Boogie",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Keep What You Got",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Dog Me Around",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Morning At Midnight",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Backslide Boogie",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Howlin' Wolf",
+            "nombre_real": "unasigned",
+            "perfil": "Blues singer, guitarist, harmonica player. A key figure in bridging the early Delta Blues with the more modern Electric Blues. His tutelage on the Mississippi Delta included guitar and showmanship from [a=Charley Patton] and harmonica teachings from [a=Sonny Boy Williamson (2)]. By the end of the 1930's he was a fixture on the Southern Club scene. He was inducted into the U.S. Army on April 9, 1941 and discharged on November 3, 1943. He then moved near West Memphis, Arkansas. In 1948 he formed a band which included guitarists [a=Willie Johnson (4)] & [url=https://www.discogs.com/artist/348055-Matt-Murphy]Matt \"Guitar\" Murphy[/url], harmonica player [a=Little Junior Parker], and drummer [a=Willie Steele (2)]. In 1951, [a=Sam Phillips (2)] recorded several songs by Howlin' Wolf at his [l=Memphis Recording Service], and he became a local celebrity. After [a=Leonard Chess] secured his contract, The Wolf relocated to Chicago in 1952. It was in Chicago that his legendary status was secured. Playing with prominent blues musicians such as [a=Willie Dixon],  [a=Jimmy Rogers] and his longtime guitarist [a=Hubert Sumlin], his everchanging lineups remained stellar thanks in part to Burnetts' admirable policies of paying his musicians well and on time, even including unemployment insurance and Social Security contributions, basically unheard of among his peers. Over the years many of his songs have been interpreted by rock bands, including  \"Little Red Rooster\", \"Back Door Man\", \"Killing Floor\", & \"Spoonful\".  [a=Howlin Wolf], with his Memphis and Chicago recordings, his status and influence, surely is one of the vital links between Blues and Rock.\r\n\r\nInducted into Rock And Roll Hall of Fame in 1991 (Early Influence).\r\n\r\nBorn June 10, 1910 West Point, Mississippi, USA.\r\nDied January 10, 1976 Hines, Illinois, USA.",
+            "url_imagen": "https://i.discogs.com/lPuL3kArOUT5vlSpD7xKAatbRK43hw9iUF5a16oj2M4/rs:fit/g:sm/q:90/h:373/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM0MDY3/OC0xMzU0MDUzNTA1/LTc5MTguanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Mississippi John Hurt - The Best Of Mississippi John Hurt",
+            "url_imagen": "https://i.discogs.com/ImNO7rmtIrutNw4IkipeDkQbLxyYyn3Bp4adxasIkeA/rs:fit/g:sm/q:90/h:500/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY4MDUw/Mi0xMjY1NzQ1MzY2/LmpwZWc.jpeg",
+            "sello": "VSD 19/20",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1971",
+            "estilos": "Delta Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Here Am I, Oh Lord, Send Me",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "I Shall Not Be Moved",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Nearer My God To Thee",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Baby What's Wrong With You",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "It Ain't Nobody's Business",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Salty Dog Blues",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Coffee Blues",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Avalon, My Home Town",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Make Me A Pallet On The Floor",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Since I've Laid This Burden Down",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Sliding Delta",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Monday Morning Blues",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "Richland Women Blues",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "Candy Man",
+                "posicion": "C4"
+            },
+            {
+                "nombre": "Stagolee",
+                "posicion": "C5"
+            },
+            {
+                "nombre": "My Creole Belle",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "C.C. Rider",
+                "posicion": "D2"
+            },
+            {
+                "nombre": "Spanish Fandango",
+                "posicion": "D3"
+            },
+            {
+                "nombre": "Talking Casey",
+                "posicion": "D4"
+            },
+            {
+                "nombre": "Chicken",
+                "posicion": "D5"
+            },
+            {
+                "nombre": "You Are My Sunshine",
+                "posicion": "D6"
+            }
+        ],
+        "artist": {
+            "nombre": "Mississippi John Hurt",
+            "nombre_real": "unasigned",
+            "perfil": "Influential country blues singer and guitarist.\r\nBorn: 8 March 1893 (exact birth date disputed) in Teoc, Carroll County, Mississippi\r\nDied: 2 November 1966 in Grenada, Mississippi, USA (heart attack)\r\n\r\nHis first recordings, made for Okeh Records in 1928, were commercial failures, and he continued to work as a farmer. Blues enthusiast located Hurt in 1963 and persuaded him to move to Washington, D.C. He was recorded by the Library of Congress in 1964. This helped further the American folk music revival, which led to the rediscovery of many other bluesmen of Hurt's era. He also went on to record several albums.",
+            "url_imagen": "https://i.discogs.com/1r-SDygfXMsHC9x-GSQA-KH7HpHtbjrGEC4So52MMDE/rs:fit/g:sm/q:90/h:472/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwNzI0/OS0xNjMyNjAyMTE3/LTg3NTQuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Butterfield Blues Band* - Live",
+            "url_imagen": "https://i.discogs.com/Hy-k2CLKa8AQy-5O9qgW0aBmYc_8fQ6bL4F6FOCwlZA/rs:fit/g:sm/q:90/h:533/w:526/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1ODQz/NTAtMTM0NzUwNzY5/NS01NDM5LmpwZWc.jpeg",
+            "sello": "7E-2001",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1970",
+            "estilos": "Chicago Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Everything Going To Be Alright",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Love Disease",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Boxer",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "No Amount Of Loving",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Driftin' And Driftin'",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Intro To Musicians",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Number Nine",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "I Want To Be With You",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "Born Under A Bad Sign",
+                "posicion": "C4"
+            },
+            {
+                "nombre": "Get Together Again",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "So Far, So Good",
+                "posicion": "D2"
+            }
+        ],
+        "artist": {
+            "nombre": "The Paul Butterfield Blues Band",
+            "nombre_real": "unasigned",
+            "perfil": "US American blues rock band, formed in 1963 by [a=Paul Butterfield].",
+            "url_imagen": "https://i.discogs.com/z-ILu5N_JOIQhmSxhuipIm80FYrSXE2lMUKDSWCVvsA/rs:fit/g:sm/q:90/h:717/w:570/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQzNzg4/MC0xMjMyNDE3NTQ5/LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Buddy Guy - Rhythm & Blues",
+            "url_imagen": "https://i.discogs.com/pR2BEtObF4boGDNq_N8FcGsRjJzx6ldWCjY1MgFrfUo/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgwOTYy/NjItMTQ1NTA1NTk5/Ny03NDg3LmpwZWc.jpeg",
+            "sello": "88883-71759-2",
+            "formato": "CD",
+            "genero": "Blues",
+            "pais": "Canada",
+            "publicado": "2013",
+            "estilos": "Chicago Blues, Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Rhythm",
+                "posicion": ""
+            },
+            {
+                "nombre": "Best In Town",
+                "posicion": "1-1"
+            },
+            {
+                "nombre": "Justifyin'",
+                "posicion": "1-2"
+            },
+            {
+                "nombre": "I Go By Feel",
+                "posicion": "1-3"
+            },
+            {
+                "nombre": "Messin' With The Kid",
+                "posicion": "1-4"
+            },
+            {
+                "nombre": "What's Up With That Woman",
+                "posicion": "1-5"
+            },
+            {
+                "nombre": "One Day Away",
+                "posicion": "1-6"
+            },
+            {
+                "nombre": "Well I Done Got Over It",
+                "posicion": "1-7"
+            },
+            {
+                "nombre": "What You Gonna Do About Me",
+                "posicion": "1-8"
+            },
+            {
+                "nombre": "The Devil's Daughter",
+                "posicion": "1-9"
+            },
+            {
+                "nombre": "Whiskey Ghost",
+                "posicion": "1-10"
+            },
+            {
+                "nombre": "Rhythm Inner Groove",
+                "posicion": "1-11"
+            },
+            {
+                "nombre": "Blues",
+                "posicion": ""
+            },
+            {
+                "nombre": "Meet Me In Chicago",
+                "posicion": "2-1"
+            },
+            {
+                "nombre": "Too Damn Bad",
+                "posicion": "2-2"
+            },
+            {
+                "nombre": "Evil Twin",
+                "posicion": "2-3"
+            },
+            {
+                "nombre": "I Could Die Happy",
+                "posicion": "2-4"
+            },
+            {
+                "nombre": "Never Gonna Change",
+                "posicion": "2-5"
+            },
+            {
+                "nombre": "All That Makes Me Happy Is The Blues",
+                "posicion": "2-6"
+            },
+            {
+                "nombre": "My Mama Loved Me",
+                "posicion": "2-7"
+            },
+            {
+                "nombre": "Blues Don't Care",
+                "posicion": "2-8"
+            },
+            {
+                "nombre": "I Came Up Hard",
+                "posicion": "2-9"
+            },
+            {
+                "nombre": "Poison Ivy",
+                "posicion": "2-10"
+            }
+        ],
+        "artist": {
+            "nombre": "Buddy Guy",
+            "nombre_real": "unasigned",
+            "perfil": "American blues guitarist and singer, born July 30th, 1936 in Lettsworth, Louisiana, and one of the pioneers of the Chicago blues sound. Began performing with bands in Baton Rouge in the '50s before moving to Chicago in 1957. He originally recorded for [l=Cobra Record Corp.] subsidiary [l=Artistic (2)] before moving to [l=Chess], where he worked as a sideman and leader when Cobra folded. During his time on Chess he also recorded under the pseudonym Friendly Chap for [l=Delmark Records]. He moved to [l=Vanguard] in 1967, and then went on to work with a variety of labels. He is the brother of [a=Phil Guy].\r\n\r\nGuy has won six Grammy awards, 23 W.C. Handy Awards, and, in 2003, he was awarded the National Medal of Arts. He was inducted into the Rock And Roll Hall of Fame in 2005, and into the Louisiana Music Hall of Fame in 2008.",
+            "url_imagen": "https://i.discogs.com/Xxu5FihWR65mxdt1rWl3q8xDm2cPSXKHFxmhtyCeWpI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1OTc5/OS0xNjU3Mzk3NjAw/LTE0OTcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "B.B. King - Six Silver Strings",
+            "url_imagen": "https://i.discogs.com/u-lmz8nsnz2UK5UAhsZPSbOcxh6qAv-JjHf-YTAEido/rs:fit/g:sm/q:90/h:547/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE3ODA2/NTAtMTQ5Mjg4Njk2/Ni0xNzUyLmpwZWc.jpeg",
+            "sello": "MCA-5616",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1985"
+        },
+        "tracklist": [
+            {
+                "nombre": "Six Silver Strings",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Big Boss Man",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "In The Midnight Hour",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Into The Night",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "My Lucille",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Memory Lane",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "My Guitar Sings The Blues",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Double Trouble",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "nombre": "B.B. King",
+            "nombre_real": "unasigned",
+            "perfil": "American blues singer, guitarist, and songwriter (September 16, 1925 near Itta Bena, Mississippi - May 14, 2015, Las Vegas, Nevada). \r\nB.B. is an abbreviation for 'Blues Boy'.\r\n\r\nKing is one of the most influential blues musicians of all time, earning the nickname \"The King of the Blues.\" He is considered one of the \"Three Kings of the Blues Guitar\" (along with [a=Albert King] and [a=Freddie King], none of whom are related). Since he started recording in the 1940s, he released over fifty albums. He previously worked as a tractor driver.\r\n\r\nIn his youth, he played on street corners for dimes, and would sometimes play in as many as four towns a night. In 1947, he hitchhiked to Memphis, TN, to pursue his music career. In Memphis, B.B. stayed with his cousin [a=Bukka White], one of the most celebrated blues performers of his time, who B.B. credits as one of his earliest mentors and teachers. King's first big break came in 1948 when he performed on [a=Sonny Boy Williamson]’s radio program on KWEM out of West Memphis. This radio performance led to steady engagements at the Sixteenth Avenue Grill in West Memphis and later to a ten-minute spot on the Memphis radio station WDIA. King's radio spot become so popular, it was expanded and became the “Sepia Swing Club.” As King worked at WDIA as a singer and disc jockey, he was given the catchy radio nickname \"Beale Street Blues Boy\", later shortened to \"Blues Boy\", and finally to \"B.B.\" \r\n\r\nIn the late 1940s and early 1950s, King was a part of the blues scene on Beale Street. \"Beale Street was where it all started for me\", King said. He performed with [a=Bobby Bland], [a=Johnny Ace], and [a=Earl Forest] in a group known as [a=The Beale Streeters]. In 1949, King made his recording debut on [l=Bullet (2)] ([l=Bullet Recording & Transcription Co.]) by issuing the single [url=https://www.discogs.com/release/7031392-BB-King-Miss-Martha-King-When-Your-Baby-Packs-Up-And-Goes]\"Miss Martha King\"[/url], which did not chart well. Later that year, he began a recording contract with Los Angeles-based [l=RPM Records (5)]. Many of King's early recordings were produced by [a=Sam Phillips (2)] (who later founded [l=Sun Record Company]). King's recording contract was followed by tours across the US, with performances in big city theatres as well as gigs in small clubs and juke joints in the southern United States. During one show in Twist, Arkansas, a fight broke out between two men and caused a fire. King evacuated with the rest of the crowd, but realizing he left his acoustic guitar inside, rushed back inside the burning building to retrieve it. He later discovered the two men were fighting over a woman named Lucille. Ever since, each one of B.B.’s trademark Gibson guitars has been called Lucille, as a reminder not to fight over women or run into any more burning buildings. \r\n\r\nIn 1952, B.B. had a number one hit with “Three O’Clock Blues,” and began touring nationally soon after. 1956 became a record-breaking year, with 342 concerts booked and three recording sessions. That same year he founded his own record label, [l=Blues Boys Kingdom], with headquarters at Beale Street in Memphis. In 1962, King signed to [l=ABC-Paramount] Records, which was later absorbed into [l=MCA Records]. In November 1964, King recorded the [m=107099] album, considered to be one of his finest recordings. In 1968, B.B. played at the [l=Newport Folk Festival] and at [a=Bill Graham (2)]’s [l=Fillmore West] on bills with the hottest contemporary rock artists of the day who idolized B.B. and helped to introduce him to a young white audience. In 1969, B.B. was chosen by [a=The Rolling Stones] as the opening act for their American tour. He won a 1970 Grammy Award for his version of the song \"The Thrill Is Gone\", which was a hit on both the Pop and R&B charts. It also gained the number 183 spot in Rolling Stone magazine's 500 Greatest Songs of All Time. From the 1980s until his death in 2015, he maintained a highly visible and active career, appearing on numerous television shows and performing as much as 300 nights a year.\r\n\r\nB.B. was inducted into the Blues Foundation Hall of Fame in 1984 and into the Rock And Roll Hall of Fame in 1987 (Performer).",
+            "url_imagen": "https://i.discogs.com/xV3Pd56I0RSs6P9ZS2SUz65Vuz8AxJU9HsiuMNDNbU0/rs:fit/g:sm/q:90/h:632/w:521/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM3NzI5/LTEzMjg2MTE0Nzku/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Keb' Mo' - Just Like You",
+            "url_imagen": "https://i.discogs.com/F4fkuPz-H8pnWRdGJM4N_S_e3LEmuQ4RnvCUAoqMfnY/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE3NTM4/MTMtMTI0MTE2ODg0/NS5qcGVn.jpeg",
+            "sello": "484117 2",
+            "formato": "CD",
+            "genero": "Blues",
+            "pais": "Europe",
+            "publicado": "1996",
+            "estilos": "Modern Electric Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "That's Not Love",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Perpetual Blues Machine",
+                "posicion": "2"
+            },
+            {
+                "nombre": "More Than One Way Home",
+                "posicion": "3"
+            },
+            {
+                "nombre": "I'm On Your Side",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Just Like You",
+                "posicion": "5"
+            },
+            {
+                "nombre": "You Can Love Yourself",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Dangerous Mood",
+                "posicion": "7"
+            },
+            {
+                "nombre": "The Action",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Hand It Over",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Standin' At The Station",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Momma, Where's My Daddy",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Last Fair Deal Gone Down",
+                "posicion": "12"
+            },
+            {
+                "nombre": "Lullaby Baby Blues",
+                "posicion": "13"
+            }
+        ],
+        "artist": {
+            "nombre": "Keb' Mo'",
+            "nombre_real": "unasigned",
+            "perfil": "Singer, songwriter, and guitarist born in south Los Angeles on October 3, 1951.",
+            "url_imagen": "https://i.discogs.com/me7cX5xHVvdpSMXFJ98d50IHvYHVO69qZal-aw-NBHU/rs:fit/g:sm/q:90/h:506/w:444/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU2OTI3/Ni0xNjY2NDg2NDYw/LTY5NDguanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Ben Harper And Charlie Musselwhite - No Mercy In This Land",
+            "url_imagen": "https://i.discogs.com/vs79_nVZC6QSPvPvBpSuAdquFp_O7O242eDKBnWUiWI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNzY4/NTA1LTE1MjIwNTIx/MTQtMzg2Mi5qcGVn.jpeg",
+            "sello": "7561-1",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "Europe",
+            "publicado": "2018"
+        },
+        "tracklist": [
+            {
+                "nombre": "When I Go",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Bad Habits",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Love And Trust",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "The Bottle Wins Again",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Found The One",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "When Love Is Not Enough",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Trust You To Dig My Grave",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "No Mercy In This Land",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Movin' On",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Nothing At All",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Ben Harper",
+            "nombre_real": "unasigned",
+            "perfil": "Benjamin Chase Harper, professionally known as Ben Harper, is an American singer-songwriter and multi-instrumentalist born October 28, 1969 in Pomona, California, USA. He was married to [a=Laura Dern] from 2005 to 2013.",
+            "url_imagen": "https://i.discogs.com/nIcGvgDn-5gp0FYMiAnuw4UbmnNqzgO6mI_9Hjt5_DQ/rs:fit/g:sm/q:90/h:520/w:520/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQyNTk5/LTE2ODU0ODEwMzgt/NTEzMi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Sonny Boy Williamson (2) - The Real Folk Blues",
+            "url_imagen": "https://i.discogs.com/yfdNFdXRxc6EpTJpvdbBXnXT0dyRRZUDjMkbEBBP_kY/rs:fit/g:sm/q:90/h:469/w:450/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI2NTYy/MjYtMTI5NTIxNzY5/NC5qcGVn.jpeg",
+            "sello": "LP-1503",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1966",
+            "estilos": "Chicago Blues, Harmonica Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "One Way Out",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Too Young To Die",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Trust My Baby",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Checkin' Up On My Baby",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Sad To Be Alone",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Got To Move",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Bring It On Home",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Down Child",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Peach Tree",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Dissatisfied",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "That's All I Want",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Too Old To Think",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Sonny Boy Williamson (2)",
+            "nombre_real": "unasigned",
+            "perfil": "American blues singer & harmonica player at the emergence of 'electric blues'. Famous compositions include \"Help Me\", \"Eyesight To The Blind\" and \"Don't Start Me Talkin'\". Not to be confused with the earlier & more 'acoustic' [a746951] (of \"Good Morning, School Girl\" fame).\r\n\r\nSubsequent research has shown that Miller was born Aleck Ford on the Sara Jones Plantation in Tallahatchie County, Mississippi. He took on the name of his sharecropper stepfather, Jim Miller. His gravestone lists his date of birth as March 11, 1908. The stone erected by his sisters in Tutwiler, MS, lists his death as 23 June 1965. Such is the mystery of blues legends.\r\n\r\nAt BMI he is known as > Songwriter/Composer: WILLIAMSON WILLIE > Current Affiliation: BMI CAE/IPI #: 63518579.\r\nFor the songlist, please use the link below.\r\n\r\nBorn: December 05, 1899 // Glendora, Miss., United States.\r\nDied: May 25, 1965 // Helena, Ark., United States.",
+            "url_imagen": "https://i.discogs.com/1V5YLKT3eQnlWonGtFYuZIwsuREYwzlAl2uVGJSuE5w/rs:fit/g:sm/q:90/h:718/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI4Nzg0/OS0xNTcyNDYwOTcw/LTg0MzEuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Culture Club - Do You Really Want To Hurt Me",
+            "url_imagen": "https://i.discogs.com/ccnktdM1NypOuuC1GhUzy530-d80XY8lzyWsLpa-Y6o/rs:fit/g:sm/q:90/h:605/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTkxNjgz/ODAtMTQ3NTk3MDAz/My02NjgxLmpwZWc.jpeg",
+            "sello": "VS 518",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK",
+            "publicado": "1982",
+            "estilos": "New Wave, Reggae-Pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Do You Really Want To Hurt Me",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Do You Really Want To Hurt Me (Dub Version)",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Culture Club",
+            "nombre_real": "unasigned",
+            "perfil": "UK pop group with reggae leanings, comprising [a=Boy George], vocals ([a=George O'Dowd], June 14, 1960), [a=Jon Moss], drums (September 11, 1957), [a=Roy Hay], guitar and keyboards (August 12, 1961) and [a=Michael Craig] (alias Mikey Craig), bass (February 15, 1960). The group split in 1986 and reformed in 1998.",
+            "url_imagen": "https://i.discogs.com/bxkZcbww0qdNSsqj0b9XHgjHmpTkwpgWGDc8wtvhfXQ/rs:fit/g:sm/q:90/h:481/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3MDYt/MTQzODU3NTA0My02/NTQ1LnBuZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Melanie Martinez (2) - Cry Baby",
+            "url_imagen": "https://i.discogs.com/DO9bIJX2O_acbLPDcemiSVHDGIMNlr5pxlzm-BvkDT0/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc3NzM4/MjAtMTY0MDY2NjU3/NC0xMDUyLmpwZWc.jpeg",
+            "sello": "549986-1",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "US",
+            "publicado": "2015",
+            "estilos": "Indie Pop, Synth-pop, Alt-Pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Cry Baby",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Dollhouse",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Sippy Cup",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Carousel",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Alphabet Boy",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Soap",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Training Wheels",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Pity Party",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Tag, You're It",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Milk And Cookies",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Pacify Her",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Mrs. Potato Head",
+                "posicion": "B6"
+            },
+            {
+                "nombre": "Mad Hatter",
+                "posicion": "B7"
+            }
+        ],
+        "artist": {
+            "nombre": "Melanie Martinez (2)",
+            "nombre_real": "unasigned",
+            "perfil": "Melanie Martinez is a vocalist with a bent toward alternative singer/songwriter pop and electronic music, who is best known for competing on the third season of NBC's vocal competition The Voice. A native of Baldwin, New York, Martinez grew up listening to her father's Beatles records and hip-hop music. In 2012, while still in high school, Martinez auditioned for, and won a spot on, NBC's The Voice with her performance of Britney Spears' \"Toxic.\" Choosing to join judge Adam Levine's team, she eventually made it to week five before getting eliminated via audience vote. In 2014, Martinez released the Kinetics- and One Love-produced EP Dollhouse on Atlantic Records.",
+            "url_imagen": "https://i.discogs.com/5za0B7JCb7BySDQbTxOAfbNYGGUj6onbgmAt32cyzoc/rs:fit/g:sm/q:90/h:423/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQxMTI4/MzktMTY4MDMxNDEz/Ni00MTkxLnBuZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Sam Smith (12) - In The Lonely Hour",
+            "url_imagen": "https://i.discogs.com/3EH_PfGJO5SkoZ5oCljstbzhkx4P54r3UVj8Me_xtww/rs:fit/g:sm/q:90/h:604/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY1MDYy/NTEtMTQyMDg5MDQ1/OC04MTczLmpwZWc.jpeg",
+            "sello": "3769173",
+            "formato": "CD",
+            "genero": "Pop",
+            "pais": "Europe",
+            "publicado": "2014",
+            "estilos": "Ballad, Europop, Synth-pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Money On My Mind",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Good Thing",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Stay With Me",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Leave Your Lover",
+                "posicion": "4"
+            },
+            {
+                "nombre": "I'm Not The Only One",
+                "posicion": "5"
+            },
+            {
+                "nombre": "I've Told You Now",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Like I Can",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Life Support",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Not In That Way",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Lay Me Down",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Restart",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Latch (Acoustic)",
+                "posicion": "12"
+            },
+            {
+                "nombre": "La La La",
+                "posicion": "13"
+            },
+            {
+                "nombre": "Make It To Me",
+                "posicion": "14"
+            }
+        ],
+        "artist": {
+            "nombre": "Sam Smith (12)",
+            "nombre_real": "unasigned",
+            "perfil": "British Singer-songwriter, b. 19 May 1992, Bishop's Stortford. \r\nWinner of BBC's Sound of 2014 poll, despite hitting UK charts with collaborations as early as 2012. ",
+            "url_imagen": "https://i.discogs.com/_kgGwJ2ClIGV2sm5IRePVzIHXLuaTSPreTOtl9XlB_Y/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzNzYz/NzctMTY2Njc5ODgy/My0xODkzLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Rex Orange County - Apricot Princess",
+            "url_imagen": "https://i.discogs.com/9eGHAg62a1LuTenQpY2h7mNbWwC0BaUE_5dMedppSsI/rs:fit/g:sm/q:90/h:588/w:588/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNTYw/MTkxLTE1MTg1MDYy/NTMtNDg4Ni5qcGVn.jpeg",
+            "sello": "AP001LP",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK, Europe & US",
+            "publicado": "2018",
+            "estilos": "Indie Pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Apricot Princess",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Television/So Far So Good",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Nothing",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Sycamore Girl",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Untitled",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "4 Seasons",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Waiting Room",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Rain Man",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Never Enough",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Happiness",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "Rex Orange County",
+            "nombre_real": "unasigned",
+            "perfil": "Alex O'Connor (born May 4, 1998), better known by his stage name Rex Orange County, is an English singer-songwriter.",
+            "url_imagen": "https://i.discogs.com/1YYNwUkALjHxKVRTr8aQD5cHYN5NoBgPnhuA0JtnDNY/rs:fit/g:sm/q:90/h:381/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU3Mjk1/MzctMTY0ODg1MTA3/Ni03NjM5LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Phil Collins - You Can't Hurry Love",
+            "url_imagen": "https://i.discogs.com/j3EYEFVNbMbZrYOocbgZj97CndIpOAT56H1_EUyq3EM/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNTE0/ODYtMTU0NDg3NDkw/NS02OTE1LmpwZWc.jpeg",
+            "sello": "VS 531",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK",
+            "publicado": "1982",
+            "estilos": "Soul"
+        },
+        "tracklist": [
+            {
+                "nombre": "You Can't Hurry Love",
+                "posicion": "A"
+            },
+            {
+                "nombre": "I Cannot Believe It's True",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Phil Collins",
+            "nombre_real": "unasigned",
+            "perfil": "British pop rock musician (drummer, singer, pianist), songwriter and actor, born 30 January 1951 in Chiswick, London, England, UK. Inducted into Songwriters Hall of Fame in 2003.\r\nBest known as a member of [a=Genesis], whom he joined in 1970 as a drummer, then becoming the lead vocalist in 1975 after the departure of [a=Peter Gabriel].\r\nHe began a solo career in 1981, while remaining a member of Genesis.\r\nFather of [a=Simon Collins] (with his first wife; marriage ended 1978); of [a=Lily Collins] (with his second wife [a=Jill Tavelman]; married, 4.8.1984, marriage ended, 1994); and of [a=Nicholas Collins] & [a=Mathew Collins] (with his third wife; married 1999, divorced 2008).\r\nHis brother was renowned cartoonist and illustrator [a=Clive Collins (4)] (MBE).",
+            "url_imagen": "https://i.discogs.com/1fWuXzdyvZ2kKrNtGd8YXhpIbGB-nam2JgFMQZhqJL4/rs:fit/g:sm/q:90/h:847/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwMTAy/OC0xNDcyOTE2OTc5/LTQyOTcuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Captain & Tennille* - Love Will Keep Us Together",
+            "url_imagen": "https://i.discogs.com/G78XPVfKPRGmy_-VHYPZPLEEU1sOva8NL0lLOBFn3OE/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEyOTY4/MDQwLTE1NDczNDE1/NDAtODk2Mi5qcGVn.jpeg",
+            "sello": "SP-4552",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "US",
+            "publicado": "1975",
+            "estilos": "Vocal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Love Will Keep Us Together",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Disney Girls",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "The Way I Want To Touch You",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Cuddle Up",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "The Good Songs",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "God Only Knows",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Honey Come Love Me",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Feel Like A Man",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Broddy Bounce",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Gentle Stranger",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "I Write The Songs",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Captain And Tennille",
+            "nombre_real": "unasigned",
+            "perfil": "American act of great popularity in the mid to late 1970's.\r\n\r\nTheir heyday was hemmed in between their two #1 hits: [m=49550], the first single from their debut album of the same name, rose to the top spot in the summer of 1975 and has remained their signature song. They reached the top of the charts again with 1979's [m=49586], which hit #1 in early 1980.\r\n\r\nIn addition, they hosted their own television show on ABC for one season in 1976/77, but quit despite solid ratings to focus on recording and touring. \r\n\r\nIn July of 1976, they were invited by First Lady Betty Ford to perform in the East Room of the White House in the presence of Queen Elizabeth II and President Gerald Ford during the country's bicentennial celebration. After a long journey, Queen Elizabeth fell asleep during their show.\r\n\r\nA husband and wife duo, they divorced in 2014 after a 39 year marriage.",
+            "url_imagen": "https://i.discogs.com/Q9qMuWZm0LzjP-z1RwU8GXr2vIdXZFvLsm2y-1UZ_DY/rs:fit/g:sm/q:90/h:332/w:294/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE1MTQ2/Ni0xMTE2NDU0NTI3/LmpwZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Barbra Streisand - Woman In Love",
+            "url_imagen": "https://i.discogs.com/HYJMRMIQqwMFGUysTjehKBAaTZTbxUChiMgSqm1hs1E/rs:fit/g:sm/q:90/h:591/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU4ODY0/NC0xNTM3MjIwNTAz/LTg5NjguanBlZw.jpeg",
+            "sello": "1-11364",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "US",
+            "publicado": "1980",
+            "estilos": "Ballad"
+        },
+        "tracklist": [
+            {
+                "nombre": "Woman In Love",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Run Wild",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Barbra Streisand",
+            "nombre_real": "unasigned",
+            "perfil": "American singer-songwriter, author, actress, writer, film producer and director, born April 24, 1942 in Brooklyn, New York, United States. She was married to [a=Elliott Gould] from 1963-1970; their son is [a=Jason Gould]. She has been married to [a=James Brolin] since 1998. [a=Roslyn Kind] is her younger half-sister.",
+            "url_imagen": "https://i.discogs.com/CTTmtSIvRJZLV481ZeYIeK4XpH6HnBnPdKPkT9iSheA/rs:fit/g:sm/q:90/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTUzMjQ4/LTE0MDUyODAzNzAt/MjUxMS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Paul Young - Come Back And Stay",
+            "url_imagen": "https://i.discogs.com/h2GoP5ctLH-2M_SF716_GAqL7KVUFV0RGkOJH4dmW_Y/rs:fit/g:sm/q:90/h:609/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTkwNTUx/MTUtMTQ3Mzk4MDY5/My04MjE3LmpwZWc.jpeg",
+            "sello": "A3636",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK",
+            "publicado": "1983",
+            "estilos": "Europop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Come Back And Stay",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Yours",
+                "posicion": "B1"
+            }
+        ],
+        "artist": {
+            "nombre": "Paul Young",
+            "nombre_real": "unasigned",
+            "perfil": "Pop-soul singer, born January 17, 1956, Luton, Bedfordshire, England.\r\nStarted out in 'Kool Kat & The Kool Kats' before joining [a=Streetband] who had the quirky hit 'Toast'. He then formed [a=The Q Tips] in 1979 performing over 700 concerts in the 3 years until going solo in 1982. It was third time lucky as the cover of [a=Marvin Gaye]'s \"Wherever I Lay My Hat\" hit No.1 in 1983, which was followed by the album \"No Parlez\" and established Paul with worldwide success.\r\n\r\nPaul Young's backing band is named [a=The Royal Family], and his backing vocalists are named [a=The Fabulous Wealthy Tarts].\r\n\r\nHe married [a=Stacey Young] (née Smith) in November 1988.\r\n",
+            "url_imagen": "https://i.discogs.com/s-2JQsaFI5LAK2pLoY9zmHJs_ZiHiel4sXS2hyMF9gU/rs:fit/g:sm/q:90/h:640/w:420/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTYzNjE3/LTE0Mjk2MDY5MDQt/OTM2MC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "France Gall - Babacar",
+            "url_imagen": "https://i.discogs.com/MCGIDk-iPdHHtSI2a9eza1eV6PRDqVa42wFAL2C8dac/rs:fit/g:sm/q:90/h:606/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTcyNzM3/OS0xNjYzOTM5OTA4/LTcxNjUuanBlZw.jpeg",
+            "sello": "242 096-1",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "France",
+            "publicado": "1987",
+            "estilos": "Chanson"
+        },
+        "tracklist": [
+            {
+                "nombre": "Papillon De Nuit",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Dancing Brave",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Babacar",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "J'irai Où Tu Iras",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Ella, Elle L'a",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Évidemment",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "La Chanson D'Azima",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Urgent D'attendre",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "C'est Bon Que Tu Sois Là",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "nombre": "France Gall",
+            "nombre_real": "unasigned",
+            "perfil": "French singer born on October 9, 1947 in Paris and died on January 7, 2018 in Neuilly-Sur-Seine, France (infection / cancer) at the age of 70. Winner of the Eurovision Song Contest 1965 with the song \"Poupée De Cire, Poupée De Son\". She was married and had a successful career in partnership with French singer-songwriter [a1585851] (whose stage name was [a332485]).",
+            "url_imagen": "https://i.discogs.com/1fHpNuoAyJWGJsoQC-wOI25BeWjy-PrZCMbAE97hxZc/rs:fit/g:sm/q:90/h:333/w:250/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1Nzg3/Ni0xNjAyMjM0MjYy/LTY4MTMuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Glenn Medeiros - Nothing's Gonna Change My Love For You",
+            "url_imagen": "https://i.discogs.com/vyeFpfLLH4NWANI-vDzDqLJSkgQGYcy9gsSzn_Ln4Y0/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM0NjA2/MDYtMTUxODYzMDMz/NC0zNjk0LmpwZWc.jpeg",
+            "sello": "AMHD 128",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "US",
+            "publicado": "1986",
+            "estilos": "Ballad"
+        },
+        "tracklist": [
+            {
+                "nombre": "Nothing's Gonna Change My Love For You (Extended Mix)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Nothing's Gonna Change My Love For You",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Nothing's Gonna Change My Love For You (Instrumental Mix)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "nombre": "Glenn Medeiros",
+            "nombre_real": "unasigned",
+            "perfil": "American pop singer born on June 24, 1970, Lihue, Hawaii.",
+            "url_imagen": "https://i.discogs.com/zArf0cPi3eWPsRCq-1kbLfN3YK34jvq86WXjoSOnYd0/rs:fit/g:sm/q:90/h:550/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyMDg4/My0xNTEwNTEzMjg2/LTMyOTkuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Nik Kershaw - I Won't Let The Sun Go Down",
+            "url_imagen": "https://i.discogs.com/jw06ynhNaviIOQnOHyDTa2nhb0ldILDdER8XYNdg2fk/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIxNzcw/MTQtMTQxMTkwNDk5/Ny02Mzc0LmpwZWc.jpeg",
+            "sello": "MCA 816",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK",
+            "publicado": "1983",
+            "estilos": "Synth-pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "I Won't Let The Sun Go Down On Me",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Dark Glasses",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Nik Kershaw",
+            "nombre_real": "unasigned",
+            "perfil": "British singer, composer and multi-instrumentalist (born on 1 March 1958).\r\nHe was born in Bristol as the younger son of a flautist and an opera singer. Kershaw grew up in Ipswich where he started to sing and play guitar in several bands until he became the today known solo artist.",
+            "url_imagen": "https://i.discogs.com/fxgZnE9z6xs9pkd0j8HLRhWGAzoHhVgWDPPjlP5qytU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU2NDct/MTU5MTU2NDc0MC01/OTY2LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Bee Gees - Timeless - The All-Time Greatest Hits",
+            "url_imagen": "https://i.discogs.com/H1SCl5ipyLufy4YeSZsFz87iBY_MlnYE-LxmhOR99es/rs:fit/g:sm/q:90/h:586/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwMTcx/NDM5LTE0OTI5NTA4/NzEtNjIwMS5qcGVn.jpeg",
+            "sello": "00602557493597",
+            "formato": "CD",
+            "genero": "Pop",
+            "pais": "Europe",
+            "publicado": "2017"
+        },
+        "tracklist": [
+            {
+                "nombre": "Spicks And Specks",
+                "posicion": "1"
+            },
+            {
+                "nombre": "New York Mining Disaster 1941",
+                "posicion": "2"
+            },
+            {
+                "nombre": "To Love Somebody",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Massachusetts",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Words",
+                "posicion": "5"
+            },
+            {
+                "nombre": "I've Gotta Get A Message To You",
+                "posicion": "6"
+            },
+            {
+                "nombre": "I Started A Joke",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Lonely Days",
+                "posicion": "8"
+            },
+            {
+                "nombre": "How Can You Mend A Broken Heart",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Jive Talkin'",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Nights On Broadway",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Fanny (Be Tender With My Love)",
+                "posicion": "12"
+            },
+            {
+                "nombre": "You Should Be Dancing",
+                "posicion": "13"
+            },
+            {
+                "nombre": "How Deep Is Your Love",
+                "posicion": "14"
+            },
+            {
+                "nombre": "Stayin' Alive",
+                "posicion": "15"
+            },
+            {
+                "nombre": "Night Fever",
+                "posicion": "16"
+            },
+            {
+                "nombre": "More Than A Woman",
+                "posicion": "17"
+            },
+            {
+                "nombre": "Too Much Heaven",
+                "posicion": "18"
+            },
+            {
+                "nombre": "Tragedy",
+                "posicion": "19"
+            },
+            {
+                "nombre": "Love You Inside Out",
+                "posicion": "20"
+            },
+            {
+                "nombre": "You Win Again",
+                "posicion": "21"
+            }
+        ],
+        "artist": {
+            "nombre": "Bee Gees",
+            "nombre_real": "unasigned",
+            "perfil": "A singing trio of brothers — [a151481], [a179142], and [a290019]. They were born on the Isle of Man to English parents, lived in Chorlton-cum-Hardy, Manchester, England, UK and during their childhood years moved to Brisbane, Australia, where they began their musical careers. Their worldwide success came when they returned to the UK and signed with producer [a272144].\r\n\r\nThe multiple award-winning group was successful for most of its forty years of recording music, but it had two distinct periods of exceptional success: as a harmonic 'soft rock' act in the late 1960s and early 1970s, and as the foremost stars of the disco music era in the late 1970s.\r\n\r\nNo matter the style, the Bee Gees sang three-part tight harmonies that were instantly recognizable; as brothers, their voices blended perfectly, in the same way that The Everly Brothers and Beach Boys did. Barry sang lead on many songs, in an R&B falsetto introduced in the disco years; Robin provided the clear vibrato lead that was a hallmark of their pre-disco music; Maurice sang high and low harmonies throughout their career. The three brothers co-wrote most of their hits, and they said that they felt like they became 'one person' when they were writing.\r\n\r\nIn 1994 [a746270] were inducted into the Songwriters Hall of Fame, in 1997 the Band was inducted into Rock And Roll Hall of Fame (Performer).\r\n\r\nThey were all given CBEs (Commander of the Order of the British Empire) in the 2001-2002 New Year's Honours List. The group's name was retired by the remaining brothers after Maurice died in January 2003.\r\n\r\nHowever, as time passed, they decided to perform occasionally under the Bee Gees banner until brother Robin Gibb died in May 2012.",
+            "url_imagen": "https://i.discogs.com/v15VkdPmPXGEDMUcvDvTbPWv6RZ0EzMc_wdqcPm2K1g/rs:fit/g:sm/q:90/h:526/w:498/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3NjY0/LTExNDkxNTM3NjUu/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Mylene Farmer* - Innamoramento",
+            "url_imagen": "https://i.discogs.com/5V4vRdwKvYOjSq13IYi-CMBehg8fN0shjjgeCK8ScP0/rs:fit/g:sm/q:90/h:541/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNDg4/NzMtMTI5MzYxODM4/Ni5qcGVn.jpeg",
+            "sello": "547 338 - 2",
+            "formato": "CD",
+            "genero": "Pop",
+            "pais": "France",
+            "publicado": "1999",
+            "estilos": "Chanson"
+        },
+        "tracklist": [
+            {
+                "nombre": "L'Amour Naissant",
+                "posicion": "1"
+            },
+            {
+                "nombre": "L'Âme-Stram-Gram",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Pas Le Temps De Vivre",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Dessine-Moi Un Mouton",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Je Te Rends Ton Amour",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Méfie-Toi",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Innamoramento",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Optimistique-Moi",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Serais-Tu Là ?",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Consentement",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Et Si Vieillir M'Était Conté",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Souviens-Toi Du Jour...",
+                "posicion": "12"
+            },
+            {
+                "nombre": "Mylenium",
+                "posicion": "13"
+            }
+        ],
+        "artist": {
+            "nombre": "Mylène Farmer",
+            "nombre_real": "unasigned",
+            "perfil": "Mylène Jeanne Gautier, known by her stage name Mylène Farmer, is a French Canadian singer-songwriter, actress, and author, born on 12 September 1961 in Montreal, Quebec.",
+            "url_imagen": "https://i.discogs.com/PL9LuVcyzLDxaFQDLp8ZgffT4UzIflgtg4N_Zt21S1Q/rs:fit/g:sm/q:90/h:738/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwNjQ1/MC0xNjY4OTgxMzkx/LTUyMjQuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Beautiful South - Carry On Up The Charts",
+            "url_imagen": "https://i.discogs.com/7BfYqOSJ25SpZfx3kIET7UlL47iT6PM-Leg07nxsc2o/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY5NDg3/MS0xMjc2MzM2NTc3/LmpwZWc.jpeg",
+            "sello": "828 572-2",
+            "formato": "CD",
+            "genero": "Pop",
+            "pais": "Europe",
+            "publicado": "1994",
+            "estilos": "Pop Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Song For Whoever",
+                "posicion": "1"
+            },
+            {
+                "nombre": "You Keep It All In",
+                "posicion": "2"
+            },
+            {
+                "nombre": "I'll Sail This Ship Alone",
+                "posicion": "3"
+            },
+            {
+                "nombre": "A Little Time",
+                "posicion": "4"
+            },
+            {
+                "nombre": "My Book",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Let Love Speak Up Itself",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Old Red Eyes Is Back",
+                "posicion": "7"
+            },
+            {
+                "nombre": "We Are Each Other",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Bell Bottomed Tear",
+                "posicion": "9"
+            },
+            {
+                "nombre": "36D",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Good As Gold (Stupid As Mud)",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Everybody's Talkin'",
+                "posicion": "12"
+            },
+            {
+                "nombre": "Prettiest Eyes",
+                "posicion": "13"
+            },
+            {
+                "nombre": "One Last Love Song",
+                "posicion": "14"
+            }
+        ],
+        "artist": {
+            "nombre": "The Beautiful South",
+            "nombre_real": "unasigned",
+            "perfil": "English alternative rock group formed at the end of the 1980s by two former members of Hull group [a245780]. The group broke up in January 2007.",
+            "url_imagen": "https://i.discogs.com/CM7DU4U-gXeMoc9VArraYajxyBGKuNLlPSYaosdrbiw/rs:fit/g:sm/q:90/h:391/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE3MTQy/Ny0xNDcwMTgwNzk1/LTgwNzkuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Carpenters* - The Singles 1974-1978",
+            "url_imagen": "https://i.discogs.com/TfY9d4ZzhSfMr1cMXd9rdnv-DZFkn4y293IC5fl9j1Q/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM5NjIy/Mi0xNTUyOTA4NDg4/LTQ0NjUuanBlZw.jpeg",
+            "sello": "AMLT 19748",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK",
+            "publicado": "1978",
+            "estilos": "Ballad, Vocal, Easy Listening"
+        },
+        "tracklist": [
+            {
+                "nombre": "Sweet, Sweet Smile",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Jambalaya (On The Bayou)",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Can't Smile Without You",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "I Won't Last A Day Without You",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "All You Get From Love Is A Love Song",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Only Yesterday",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Solitaire",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Please Mr. Postman",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "I Need To Be In Love",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Happy",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "There's A Kind Of Hush",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Calling Occupants Of Interplanetary Craft (The Recognized Anthem of World Contact Day)",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Carpenters",
+            "nombre_real": "unasigned",
+            "perfil": "American vocal and instrumental duo consisting of sister Karen, and brother Richard Carpenter.\r\n\r\nCarpenters were the #1 selling American music act of the 1970's. Though often referred to as \"The Carpenters,\" their name on official releases and press materials was \"Carpenters.\" During a period in the 1970's when louder and wilder rock was in great demand, Richard and Karen produced a distinctively soft musical style that made them among the best-selling music artists of all time.\r\n\r\nOriginally from New Haven, Connecticut, their parents decided to move the family west to Los Angeles, California. Richard and Karen originally played jazz, with Karen having an interest in playing the drums. They were briefly known as Spectrum and then Carpenters, where they then recorded for a small label, [l=Magic Lamp Records]. In their move West, they met Lou Adler who introduced them to [a=Herb Alpert], who signed them to his label, [l=A&M Records] in 1969.\r\n\r\nWhile Richard penned compositions with writing partner, [a=John Bettis], many of the duos' hits were written by others and some were cover versions of established hits for other artists, such as [a=The Beatles] and Motown's, [a=The Marvelettes]. Their 1973 album, \"Now and Then.\" B-side consists of a 9-song medley of 60's hits recorded like a radio show.\r\n\r\nCarpenters' melodic pop, produced a record-breaking run of hits on the American Top 40 and Adult Contemporary charts, and they became leading sellers in the soft rock, easy listening and adult contemporary genres. Carpenters had three #1 singles on the Billboard Hot 100 and fifteen #1 hits on the Adult Contemporary Chart. In addition, they had twelve top 10 singles (including their #1 hits). To date, Carpenters' album and single sales total more than 100 million units.\r\n\r\nDuring their 14-year career, Carpenters recorded 11 albums, five of which contained top 10 singles (\"[m=84990],\" \"[m=84975],\" \"[m=84966],\" \"[m=85055]\" and \"[m=85013],\") thirty-one singles, five television specials, and one short-lived television series. They toured the United States, United Kingdom, Japan, Australia, The Netherlands and Belgium. Their recording career ended with Karen's death in 1983 from cardiac arrest due to complications of anorexia nervosa. Extensive news coverage of the circumstances surrounding her death increased public awareness of the consequences of eating disorders. ",
+            "url_imagen": "https://i.discogs.com/5uwGE1CI-6INowIM4jslX0xioOnPGUZ23Wnsk7PAlss/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE3MDM1/Ny0xNjQ1MzAwNDc5/LTc2NjUuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Cock Robin - When Your Heart Is Weak",
+            "url_imagen": "https://i.discogs.com/FExKK4eNsIdjkYQ3MpXMbEPhBxJmjTfxZtxjOB9XnJE/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY3MjQ2/OC0xMzc5NDUzNzUx/LTU3NzYuanBlZw.jpeg",
+            "sello": "CBSA 6214",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "Europe",
+            "publicado": "1985",
+            "estilos": "Pop Rock, Synth-pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "When Your Heart Is Weak",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Because It Keeps On Working",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Cock Robin",
+            "nombre_real": "unasigned",
+            "perfil": "US Pop/Rock band, mostly popular in the 1980's, particularly in Europe. The band was founded in 1982 by singer/songwriter Peter Kingsbery. Originally with 4 members, Molino III and Wright left before the release of the band's second album in 1987. Kingsbery and LaCazio stayed on as a duo for a third album in 1989 but split up in 1990 after their Europe tour. After a 16-year hiatus, Kingsbery and LaCazio reformed Cock Robin in 2006 and released 2 more albums before LaCazio decided to leave in 2015 and relocate to the US. Cock Robin nowadays is fronted by Peter Kingsbery with Coralie Vuillemin as vocalist during live shows. A new album was released in March 2016 with additional vocals by Agathe Cagin and Julie Wingins. Drummers Marc Jacquemin and Didier Strub also complete the band line-up for live shows. A 5-track EP was released in April 2017 with 2 new original tracks (one instrumental), 2 covers from Peter Kingsbery's solo albums and 1 cover from Cock Robin's first album, with new arrangements and vocals by Kingsbery and Vuillemin. In September 2021, Cock Robin, consisting now of Kingsbery, Vuillemin and Strub, released a new 14-track album called \"Homo Alien\".\r\n\r\nBand settings :\r\nPeter Kingsbery: Lead vocals, Keyboards, Bass. (1982-1990 / 2006-present)\r\nAnna LaCazio: Lead vocals, Casio keyboards. (1982-1990 / 2006-2015)\r\nLouis Molino III: Drums, Percussion, backing vocals. (1982-1987)\r\nClive Wright: Guitars, Roland GR 300.(1982-1987 + On/off contributions)\r\nCoralie Vuillemin: Lead vocals, keyboards, percussions. (2015-present)\r\nDidier Strub: Drums (2015-present)\r\n\r\n",
+            "url_imagen": "https://i.discogs.com/1zO2DlXLe36abu7iFFtlE0oCF8RyY0k4G2tE_yHUYUQ/rs:fit/g:sm/q:90/h:268/w:330/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE2NjA5/My0xMDc0MDY1NzIw/LmpwZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "FINNEAS - Optimist",
+            "url_imagen": "https://i.discogs.com/eURhs96XvZMXWQtrXZtodSxp7TD2wQifZ0z_r08Dq-w/rs:fit/g:sm/q:90/h:542/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIwNTg0/NjQ1LTE2MzQyOTI2/OTMtMjMwMy5qcGVn.jpeg",
+            "sello": "00602438604876",
+            "formato": "CD",
+            "genero": "Pop",
+            "pais": "Europe",
+            "publicado": "2021"
+        },
+        "tracklist": [
+            {
+                "nombre": "A Concert Six Months From Now",
+                "posicion": "1"
+            },
+            {
+                "nombre": "The Kids Are All Dying",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Happy Now?",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Only A Lifetime",
+                "posicion": "4"
+            },
+            {
+                "nombre": "The 90s",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Love Is Pain",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Peaches Etude",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Hurt Locker",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Medieval",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Someone Else’s Star",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Around My Neck",
+                "posicion": "11"
+            },
+            {
+                "nombre": "What They’ll Say About Us",
+                "posicion": "12"
+            },
+            {
+                "nombre": "How It Ends",
+                "posicion": "13"
+            }
+        ],
+        "artist": {
+            "nombre": "FINNEAS",
+            "nombre_real": "unasigned",
+            "perfil": "Stage name of [a6016928] (born July 30, 1997). American actor, musician, and music producer. Brother of [a5590213].\r\n",
+            "url_imagen": "https://i.discogs.com/PQlYP783fhy77rMVYfEA7UMTDpfBZH9exJRDUrorOIQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTUzMjQ0/MzItMTYzMjczOTc1/OC04OTM1LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "The Bee Gees* - Spicks And Specks",
+            "url_imagen": "https://i.discogs.com/wKlz4DmBe5Xy4BpaetKR0K74ThwdZSLXXHVPDVG4fWQ/rs:fit/g:sm/q:90/h:451/w:451/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEzODYz/OTctMTIxNTE4ODQ1/MC5qcGVn.jpeg",
+            "sello": "EL 32031",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "Australia",
+            "publicado": "1966",
+            "estilos": "Beat"
+        },
+        "tracklist": [
+            {
+                "nombre": "Monday's Rain",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "How Many Birds",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Playdown",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Second Hand People",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "I Don't Know Why I Bother With Myself",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Big Chance",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Spicks And Specks",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Jingle Jangle",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Tint Of Blue",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Where Are You?",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Born A Man",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Glass House",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Bee Gees",
+            "nombre_real": "unasigned",
+            "perfil": "A singing trio of brothers — [a151481], [a179142], and [a290019]. They were born on the Isle of Man to English parents, lived in Chorlton-cum-Hardy, Manchester, England, UK and during their childhood years moved to Brisbane, Australia, where they began their musical careers. Their worldwide success came when they returned to the UK and signed with producer [a272144].\r\n\r\nThe multiple award-winning group was successful for most of its forty years of recording music, but it had two distinct periods of exceptional success: as a harmonic 'soft rock' act in the late 1960s and early 1970s, and as the foremost stars of the disco music era in the late 1970s.\r\n\r\nNo matter the style, the Bee Gees sang three-part tight harmonies that were instantly recognizable; as brothers, their voices blended perfectly, in the same way that The Everly Brothers and Beach Boys did. Barry sang lead on many songs, in an R&B falsetto introduced in the disco years; Robin provided the clear vibrato lead that was a hallmark of their pre-disco music; Maurice sang high and low harmonies throughout their career. The three brothers co-wrote most of their hits, and they said that they felt like they became 'one person' when they were writing.\r\n\r\nIn 1994 [a746270] were inducted into the Songwriters Hall of Fame, in 1997 the Band was inducted into Rock And Roll Hall of Fame (Performer).\r\n\r\nThey were all given CBEs (Commander of the Order of the British Empire) in the 2001-2002 New Year's Honours List. The group's name was retired by the remaining brothers after Maurice died in January 2003.\r\n\r\nHowever, as time passed, they decided to perform occasionally under the Bee Gees banner until brother Robin Gibb died in May 2012.",
+            "url_imagen": "https://i.discogs.com/v15VkdPmPXGEDMUcvDvTbPWv6RZ0EzMc_wdqcPm2K1g/rs:fit/g:sm/q:90/h:526/w:498/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3NjY0/LTExNDkxNTM3NjUu/anBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Aztec Camera - Oblivious",
+            "url_imagen": "https://i.discogs.com/C5VXwYZugGre2iFhEyuRGblVmgKOb8YN_puRWAu1npk/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMyNDU4/OC0xNTkwMDA0OTc3/LTY1MDcuanBlZw.jpeg",
+            "sello": "RT 122",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "UK",
+            "publicado": "1983",
+            "estilos": "Indie Pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Oblivious",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Orchid Girl",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "nombre": "Aztec Camera",
+            "nombre_real": "unasigned",
+            "perfil": "Scottish new-wave/indie pop band founded by Roddy Frame in 1980 in East Kilbride, Scotland, United Kingdom. Disbanded in 1995.",
+            "url_imagen": "https://i.discogs.com/ayNeQg4e05Lkdre9bUCKbjw_3kmFIewXSbnERMYnMao/rs:fit/g:sm/q:90/h:450/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTczMTk0/LTE1OTExNzczNjgt/MjMyNS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "titulo": "Bobby Vinton - Bobby Vinton's Greatest Hits",
+            "url_imagen": "https://i.discogs.com/1_Oskmby8PwTBOAHfTx67R0gKGY1Lt-wJhTVDUSe8lY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIxOTYx/MjEtMTM1MDE3NzU4/Ni04MzE5LmpwZWc.jpeg",
+            "sello": "BN 26098",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "US",
+            "publicado": "1965",
+            "estilos": "Ballad, Vocal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Blue Velvet",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Roses Are Red (My Love)",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Blue On Blue",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Mr. Lonely",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Let's Kiss And Make Up",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "My Heart Belongs To Only You",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "There! I've Said It Again",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Rain Rain Go Away",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "I Love You The Way You Are",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Over The Mountain",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Trouble Is My Middle Name",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Tell Me Why",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "nombre": "Bobby Vinton",
+            "nombre_real": "unasigned",
+            "perfil": "American pop music singer, born on April 16, 1935, in Canonsburg, Pennsylvania.",
+            "url_imagen": "https://i.discogs.com/1i6KRm38tN-xmQtWVIBE1ftII_Glo1JKj2gOdFjg9as/rs:fit/g:sm/q:90/h:718/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE1NDk3/MS0xMzk1NTA1NTI0/LTE0ODguanBlZw.jpeg"
+        }
+    }
+]

--- a/src/front/js/pages/ArticleDetails.jsx
+++ b/src/front/js/pages/ArticleDetails.jsx
@@ -14,7 +14,7 @@ const ArticleDetails = () => {
         <div className="container mt-3">
             <div className="row">
                 <div className="col-md-3">
-                    <img src={process.env.BACKEND_URL + "api/utils/images/" + element.url_imagen} alt="{element.title}"
+                    <img src={element.url_imagen} alt="{element.title}"
                         className="img-fluid" />
                 </div>
                 <div className="col-md-7">

--- a/src/front/js/pages/Explorer.jsx
+++ b/src/front/js/pages/Explorer.jsx
@@ -56,13 +56,13 @@ const Explorer = () => {
                                     <li key={index}>
                                         <Link
                                             to={`/article/${element.id}`}
-                                            state={{element: element}}
+                                            state={{ element: element }}
                                         >
                                             <ArticleCard
                                                 key={index}
                                                 title={title}
                                                 artist={artist}
-                                                url_imagen={process.env.BACKEND_URL + "api/utils/images/" + element.url_imagen}
+                                                url_imagen={element.url_imagen}
                                             />
                                         </Link>
                                     </li>


### PR DESCRIPTION
Se modifica la carga inicial para implementar cloudinary para el almacenamiento de imagenes
Se genera un archivo json con la información de la api externa de discosg para no tener que estar consultando esta API cada vez que se haga la carga inicial
