### PR TITLE
Fix a carga inicial

### DIFF
--- a/src/api/data/data_inicial.json
+++ b/src/api/data/data_inicial.json
@@ -1,886 +1,36 @@
 [
     {
         "release": {
-            "titulo": "Theo Parrish - Detroit Beatdown Remixes 1:2",
-            "url_imagen": "https://i.discogs.com/58ybvhDYeZJgOpFpJ96aCc2ZkXssPMX55QKirfOReaI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU0NTMx/OS0xMjg3OTQzMjU5/LmpwZWc.jpeg",
-            "sello": "3EEP-038",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "2005",
-            "estilos": "Techno, Deep House"
-        },
-        "tracklist": [
-            {
-                "nombre": "Falling Up (Carl Craig Remix)",
-                "posicion": "A"
-            }
-        ],
-        "artist": {
-            "nombre": "Theo Parrish",
-            "nombre_real": "unasigned",
-            "perfil": "American electronic DJ, and producer. \r\n\r\nBorn: 1972 in Washington DC, USA. \r\n\r\nGrowing up in Chicago, later Detroit-based house music producer, Parrish is internationally well known for his own inimitable downtempo house music style. \r\n\r\nHe is also a label owner, with both [l=Sound Signature] and [l=Ugly Edits] probably being his best known ones. \r\n",
-            "url_imagen": "https://i.discogs.com/w9ZO-BukhS00EfqGlf8RnoTKBvPGNUssA8n27qltDQE/rs:fit/g:sm/q:90/h:382/w:334/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE0OS0x/NTA0ODIwNTIyLTcz/NzUuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "I-f - Space Invaders Are Smoking Grass",
-            "url_imagen": "https://i.discogs.com/zpRrLPlxDJWwqs5oA0kZ61eN6mFODcQRGi9j8jUVP8Q/rs:fit/g:sm/q:90/h:595/w:595/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5NDYw/LTExNDgyNDU4ODAu/anBlZw.jpeg",
-            "sello": "IT No. 9",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "US",
-            "publicado": "1998",
-            "estilos": "Electro"
-        },
-        "tracklist": [
-            {
-                "nombre": "Space Invaders Are Smoking Grass (Extended 12\" Version)",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Untitled",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Space Invaders Are Smoking Grass (Original)",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Secret Desire (Instrumental)",
-                "posicion": "B2"
-            }
-        ],
-        "artist": {
-            "nombre": "I-f",
-            "nombre_real": "unasigned",
-            "perfil": "Dutch DJ and producer. I-f, short for [a=Interr-Ference], also known as Ferenc, [a=Beverly Hills 808303].",
-            "url_imagen": "https://i.discogs.com/fHKqm9v8EVfvUQ8pJlmsewyOVgW70Cc9EzlfamvwKRg/rs:fit/g:sm/q:90/h:399/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE0NjAt/MTQ5MjA4NTI2OC04/OTI5LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Sound Stream - \"Live\" Goes On",
-            "url_imagen": "https://i.discogs.com/AMaHeADkq7toetZP7n9ncn9nKSYURL8KvsiRy6Rkl0s/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0MzM2/NTAtMTQ3OTI1ODQz/Ny00MTM4LmpwZWc.jpeg",
-            "sello": "SST 04",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "Germany",
-            "publicado": "2008",
-            "estilos": "House, Deep House, Disco"
-        },
-        "tracklist": [
-            {
-                "nombre": "\"Live\" Goes On",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Rainmaker",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Dance With Me",
-                "posicion": "B2"
-            }
-        ],
-        "artist": {
-            "nombre": "Sound Stream",
-            "nombre_real": "unasigned",
-            "perfil": "",
-            "url_imagen": "https://i.discogs.com/rRf7BIFcH8cuBHbc5bhfsWS2CrAZkGzYCqQ1bW_sZXc/rs:fit/g:sm/q:90/h:446/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwMDk4/LTE0Mjc0NDQ2NDAt/NDg2NC5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "John B - Up All Night / Take Control",
-            "url_imagen": "https://i.discogs.com/WENvqOMA_QvDc_l__rut1_BykZ9icB68JVT5rLjlHD4/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM3OTQt/MTYwNjgxMjk5My01/MjA0LmpwZWc.jpeg",
-            "sello": "METH 041",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "2001",
-            "estilos": "Drum n Bass"
-        },
-        "tracklist": [
-            {
-                "nombre": "Up All Night",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Take Control",
-                "posicion": "AA"
-            }
-        ],
-        "artist": {
-            "nombre": "John B",
-            "nombre_real": "unasigned",
-            "perfil": "Drum & Bass DJ & producer, based in the UK. \r\nOwns & runs the [l=Beta Recordings] label, along with its sublabels: [l=Chihuahua Recordings], [l=Nu Electro Recordings], [l=Tangent Recordings].\r\n",
-            "url_imagen": "https://i.discogs.com/tWPWa0pZ_BlQ2JzLyHyhvCsnAXhjmPhzaMleARBmAX0/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwOS0x/NjkwMDc0Mzg2LTIy/ODYuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Tim Hecker - Ravedeath, 1972",
-            "url_imagen": "https://i.discogs.com/u_sMg6x0q_rAeeRobsHsWL-U3iB7xu9Sn3cV1ddPORU/rs:fit/g:sm/q:90/h:594/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI3NDQ3/NzctMTMwNDE5OTUz/NC5qcGVn.jpeg",
-            "sello": "krank154",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "US",
-            "publicado": "2011",
-            "estilos": "Abstract, Ambient, Experimental, Drone"
-        },
-        "tracklist": [
-            {
-                "nombre": "The Piano Drop",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "In The Fog: I-II",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "In The Fog: III",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "No Drums",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Hatred Of Music: I",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Hatred Of Music: II",
-                "posicion": "C1"
-            },
-            {
-                "nombre": "Analog Paralysis, 1978",
-                "posicion": "C2"
-            },
-            {
-                "nombre": "Studio Suicide, 1980",
-                "posicion": "C3"
-            },
-            {
-                "nombre": "In The Air: I-III",
-                "posicion": "D"
-            }
-        ],
-        "artist": {
-            "nombre": "Tim Hecker",
-            "nombre_real": "unasigned",
-            "perfil": "Tim Hecker is an electronic musician and sound artist based in Los Angeles, United States and Montreal, Canada. Hecker initially recorded under the moniker Jetone, but has become known internationally for recordings released under his own name.\r\n\r\nHas worked for the government.",
-            "url_imagen": "https://i.discogs.com/FlSSBRySwtl74do9nrLvFo_xma0A-RwMz9A_jRptffA/rs:fit/g:sm/q:90/h:771/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU5OTA2/LTE1MzMyNDc3MzQt/NTYzNy5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Mathew Jonson - Decompression EP",
-            "url_imagen": "https://i.discogs.com/CkRsG4rdYyTSW9usMOsAdepbEjiK3_Q1Cz8qJt63G5Q/rs:fit/g:sm/q:90/h:595/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMxMzc0/NC0xNjMxMTkzMzc2/LTI2NzMuanBlZw.jpeg",
-            "sello": "MINUS24",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "Canada",
-            "publicado": "2004",
-            "estilos": "Techno, Minimal"
-        },
-        "tracklist": [
-            {
-                "nombre": "Decompression",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Ultraviolet Dream",
-                "posicion": "B"
-            }
-        ],
-        "artist": {
-            "nombre": "Mathew Jonson",
-            "nombre_real": "unasigned",
-            "perfil": "Canadian electronic music producer, performer and label owner, born in Vancouver but now based in Berlin (Germany). He is one of the founders of [l=Wagon Repair] and in 2012 he became the new owner of [l=Itiswhatitis Recordings].\r\n\r\nHe is the brother of [a=Nathan Jonson], [a=Holly Jonson].",
-            "url_imagen": "https://i.discogs.com/aUOEWiAxBMCb0BWzamMDgYrStSG92ZLbaIkCAWphSpA/rs:fit/g:sm/q:90/h:400/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTUyMDAw/LTE0NDg4MTg0NDUt/NTI3NC5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Motor City Drum Ensemble - Raw Cuts # 3 / Raw Cuts # 4",
-            "url_imagen": "https://i.discogs.com/-8U6wVQ5UrhLljH2Gk8KVQSbEIQ8Vb-K58vSFtFyJEc/rs:fit/g:sm/q:90/h:490/w:490/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0ODcx/MzktMTM0MzA2NTM3/OC02ODQ2LmpwZWc.jpeg",
-            "sello": "MCDE 1202",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "Netherlands",
-            "publicado": "2008",
-            "estilos": "Deep House, Disco"
-        },
-        "tracklist": [
-            {
-                "nombre": "Raw Cuts # 3",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Raw Cuts # 4",
-                "posicion": "B"
-            }
-        ],
-        "artist": {
-            "nombre": "Motor City Drum Ensemble",
-            "nombre_real": "unasigned",
-            "perfil": "Primary alias of Danilo Plessow, a house producer and DJ from Stuttgart, Germany. ",
-            "url_imagen": "https://i.discogs.com/0kESMPw0B_KgU-gOpKMtUcws5DA9fEo0YJgI4PmtvTk/rs:fit/g:sm/q:90/h:314/w:431/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3MDkw/NS0xNTEwNzU1MTQw/LTc4MDEuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Daft Punk - Alive 2007 / Alive 1997",
-            "url_imagen": "https://i.discogs.com/JP10P3RCIE-P_hYLBTzLJTT3zGNofWvkbFdIIRQq4Pc/rs:fit/g:sm/q:90/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5NDEw/NTgtMTI1Mzg4Njc4/MS5qcGVn.jpeg",
-            "sello": "5099996753422",
-            "formato": "Box Set",
-            "genero": "Electronic",
-            "pais": "France",
-            "publicado": "2009",
-            "estilos": "House, Abstract, Disco, Techno, Electro, Experimental"
-        },
-        "tracklist": [
-            {
-                "nombre": "Alive 2007",
-                "posicion": ""
-            },
-            {
-                "nombre": "Robot Rock",
-                "posicion": "1-01"
-            },
-            {
-                "nombre": "Oh Yeah",
-                "posicion": "1-02"
-            },
-            {
-                "nombre": "Touch It",
-                "posicion": "1-03"
-            },
-            {
-                "nombre": "Technologic",
-                "posicion": "1-04"
-            },
-            {
-                "nombre": "Television Rules The Nation",
-                "posicion": "1-05"
-            },
-            {
-                "nombre": "Crescendolls",
-                "posicion": "1-06"
-            },
-            {
-                "nombre": "Too Long",
-                "posicion": "1-07"
-            },
-            {
-                "nombre": "Steam Machine",
-                "posicion": "1-08"
-            },
-            {
-                "nombre": "Around The World",
-                "posicion": "1-09"
-            },
-            {
-                "nombre": "Harder Better Faster Stronger",
-                "posicion": "1-10"
-            },
-            {
-                "nombre": "Burnin'",
-                "posicion": "1-11"
-            },
-            {
-                "nombre": "Too Long",
-                "posicion": "1-12"
-            },
-            {
-                "nombre": "Face To Face",
-                "posicion": "1-13"
-            },
-            {
-                "nombre": "Short Circuit",
-                "posicion": "1-14"
-            },
-            {
-                "nombre": "One More Time",
-                "posicion": "1-15"
-            },
-            {
-                "nombre": "Aerodynamic",
-                "posicion": "1-16"
-            },
-            {
-                "nombre": "Aerodynamic Beats",
-                "posicion": "1-17"
-            },
-            {
-                "nombre": "Forget About The World",
-                "posicion": "1-18"
-            },
-            {
-                "nombre": "Prime Time Of Your Life",
-                "posicion": "1-19"
-            },
-            {
-                "nombre": "Brainwasher",
-                "posicion": "1-20"
-            },
-            {
-                "nombre": "Rollin' And Scratchin'",
-                "posicion": "1-21"
-            },
-            {
-                "nombre": "Alive",
-                "posicion": "1-22"
-            },
-            {
-                "nombre": "Da Funk",
-                "posicion": "1-23"
-            },
-            {
-                "nombre": "Daftendirekt",
-                "posicion": "1-24"
-            },
-            {
-                "nombre": "Superheroes",
-                "posicion": "1-25"
-            },
-            {
-                "nombre": "Human After All",
-                "posicion": "1-26"
-            },
-            {
-                "nombre": "Rock'n Roll",
-                "posicion": "1-27"
-            },
-            {
-                "nombre": "Alive 1997",
-                "posicion": ""
-            },
-            {
-                "nombre": "Wdpk Part 1",
-                "posicion": "2a"
-            },
-            {
-                "nombre": "Da Funk",
-                "posicion": "2b"
-            },
-            {
-                "nombre": "Rollin' And Scratchin'",
-                "posicion": "2c"
-            },
-            {
-                "nombre": "Wdpk Part 2",
-                "posicion": "2d"
-            },
-            {
-                "nombre": "Alive",
-                "posicion": "2e"
-            }
-        ],
-        "artist": {
-            "nombre": "Daft Punk",
-            "nombre_real": "unasigned",
-            "perfil": "Daft Punk were a French electronic music duo formed in 1993 by [a=Thomas Bangalter] (born January 3, 1975) and [a=Guy-Manuel de Homem-Christo] (born February 8, 1974). Bangalter and de Homem-Christo were previously in the rock band [a=Darlin'] with [a=Laurent Brancowitz]. After Brancowitz left the group to join his brother's band, [a=Phoenix], the remaining duo formed Daft Punk. On February 22, 2021, it was announced that they had disbanded for unknown reasons.",
-            "url_imagen": "https://i.discogs.com/sP_wDoC5MsG9lZUfb9thLbpmMmL__nuVnGMNpwgjirE/rs:fit/g:sm/q:90/h:438/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyODkt/MTYxNTQ4NDUyOS00/Mjg0LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "2 Bad Mice - Hold It Down",
-            "url_imagen": "https://i.discogs.com/KLqJB-tIoR0JlWqYnH0xBg1esb2p-haAiIxTGOzLJcw/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxMTct/MTI4ODQ1NTg1NS5q/cGVn.jpeg",
-            "sello": "SHADOW 14",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "1992",
-            "estilos": "Breakbeat, Hardcore"
-        },
-        "tracklist": [
-            {
-                "nombre": "This Side",
-                "posicion": ""
-            },
-            {
-                "nombre": "Bomb Scare",
-                "posicion": "X1"
-            },
-            {
-                "nombre": "2 Bad Mice (Remix)",
-                "posicion": "X2"
-            },
-            {
-                "nombre": "Other Side",
-                "posicion": ""
-            },
-            {
-                "nombre": "Hold It Down",
-                "posicion": "Y1"
-            },
-            {
-                "nombre": "Ware Mouse",
-                "posicion": "Y2"
-            }
-        ],
-        "artist": {
-            "nombre": "2 Bad Mice",
-            "nombre_real": "unasigned",
-            "perfil": "Formed in 1991, 2 Bad Mice (the name originating from The Tale of 2 Bad Mice by Beatrix Potter) are widely credited as among the first U.K. hardcore acts to begin heavily incorporating breakbeats into the style. Consisting of members Sean O'Keeffe, Simon Colebrooke and producer Rob Playford (owner of Moving Shadow records), 2 Bad Mice were a staple on the early-to mid '90s hardcore scene and were instrumental in the music's steady mutation into jungle/drum'n'bass. The group's influential approach to sampled beats -- cutting them up into shards of rhythm and rearranging them in novel combinations (first appearing in mature form on the 1992 hit \"Bombscare\") is generally considered the blueprint from which jungle's characteristic manipulation of breaks was assembled. \r\n\r\nAlthough 2 Bad Mice for the most part stopped producing as the hardcore scene began to wane (Playford focusing his energy on Moving Shadow, now one of the most influential jungle labels), a best-of compilation of the group's work appeared on the American Sm:)e Communications label in 1995. These days Playford continues to work in production, while O'Keeffe, Colebrooke (and Paul Rhodes) currently DJ worldwide as 2 Bad Mice. ",
-            "url_imagen": "https://i.discogs.com/7f6YIt2QTGGemhaRHpeQcJ8NS79KmbL8Yfi4-6Wz1RA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwNzYt/MTY0OTcxNDQ4My02/MjY1LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Autechre - Oversteps",
-            "url_imagen": "https://i.discogs.com/RM2Tli20zio7oEGywwaKEkSsh2LhfMBstDM4CI2GB8Y/rs:fit/g:sm/q:90/h:540/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIxOTIw/NTMtMTM3OTQ2OTE5/OS0zMTk1LmpwZWc.jpeg",
-            "sello": "WARPCD210",
-            "formato": "CD",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "2010",
-            "estilos": "Abstract, IDM, Ambient"
-        },
-        "tracklist": [
-            {
-                "nombre": "r ess",
-                "posicion": "1"
-            },
-            {
-                "nombre": "ilanders",
-                "posicion": "2"
-            },
-            {
-                "nombre": "known(1)",
-                "posicion": "3"
-            },
-            {
-                "nombre": "pt2ph8",
-                "posicion": "4"
-            },
-            {
-                "nombre": "qplay",
-                "posicion": "5"
-            },
-            {
-                "nombre": "see on see",
-                "posicion": "6"
-            },
-            {
-                "nombre": "Treale",
-                "posicion": "7"
-            },
-            {
-                "nombre": "os veix3",
-                "posicion": "8"
-            },
-            {
-                "nombre": "O=0",
-                "posicion": "9"
-            },
-            {
-                "nombre": "d-sho qub",
-                "posicion": "10"
-            },
-            {
-                "nombre": "st epreo",
-                "posicion": "11"
-            },
-            {
-                "nombre": "redfall",
-                "posicion": "12"
-            },
-            {
-                "nombre": "krYlon",
-                "posicion": "13"
-            },
-            {
-                "nombre": "Yuop",
-                "posicion": "14"
-            }
-        ],
-        "artist": {
-            "nombre": "Autechre",
-            "nombre_real": "unasigned",
-            "perfil": "An English electronic music duo formed in 1987 in Rochdale, Greater Manchester, UK by [a=Rob Brown (3)] and [a=Sean Booth]. Generally considered to be IDM in style, their music has incorporated a variety of genres and styles ranging from techno and hip hop to ambient, experimental electro, and musique concrète. Autechre use many different digital and analog synthesizers, samplers, and drum machines in their production. They are also heavily involved with the [a=Gescom] collective.",
-            "url_imagen": "https://i.discogs.com/8-BdhyrSloFj_ieDxcoRiVb3ghUtwYDyLRsuA5Aplbg/rs:fit/g:sm/q:90/h:326/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQxLTEz/NjczNDQ3NDktMzM0/Mi5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Coil Presents Black Light District - A Thousand Lights In A Darkened Room",
-            "url_imagen": "https://i.discogs.com/v7LTTMCsKN7igpLfkO-GVjjUSUQu2AVZXKgbJFH_r4M/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4MzQ2/Mi0xMjcwOTQzOTgw/LmpwZWc.jpeg",
-            "sello": "ESKATON 008",
-            "formato": "CD",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "1996",
-            "estilos": "Experimental, Minimal, Ambient"
-        },
-        "tracklist": [
-            {
-                "nombre": "Unprepared Piano",
-                "posicion": "1"
-            },
-            {
-                "nombre": "Red Skeletons",
-                "posicion": "2"
-            },
-            {
-                "nombre": "Die Wölfe Kommen Zurück",
-                "posicion": "3"
-            },
-            {
-                "nombre": "Refusal Of Leave To Land",
-                "posicion": "4"
-            },
-            {
-                "nombre": "Stoned Circular I",
-                "posicion": "5"
-            },
-            {
-                "nombre": "Stoned Circular II",
-                "posicion": "6"
-            },
-            {
-                "nombre": "Green Water",
-                "posicion": "7"
-            },
-            {
-                "nombre": "Cold Dream Of An Earth Star",
-                "posicion": "8"
-            },
-            {
-                "nombre": "Blue Rats",
-                "posicion": "9"
-            },
-            {
-                "nombre": "Scratches And Dust",
-                "posicion": "10"
-            },
-            {
-                "nombre": "Chalice",
-                "posicion": "11"
-            }
-        ],
-        "artist": {
-            "nombre": "Coil",
-            "nombre_real": "unasigned",
-            "perfil": "Formed in London in 1983 by [a=John Balance] as a solo side project to Psychic TV, Coil developed into a full-scale musical group in 1984, when Balance cemented a partnership with Peter 'Sleazy' Christopherson. Christopherson had been a founder of Psychic TV and member of Throbbing Gristle. \r\nJohn Balance (1962–2004) died tragically in an accident at his home on November 13th, 2004.\r\nPeter Christopherson decided that, with the passing of John Balance, Coil would not continue.\r\nPeter Martin Christopherson died 25 November 2010 (aged 55).",
-            "url_imagen": "https://i.discogs.com/tULNZQb7PuNXUDwoJ_gx46KUag91H46c98o2QFBd64o/rs:fit/g:sm/q:90/h:664/w:450/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY2MC0x/NTM3MDAxOTAyLTM0/NDIuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Moodymann - Silence In The Secret Garden",
-            "url_imagen": "https://i.discogs.com/PJyEvph256nP5jN87VD1xiBfaQ50yQfSxA9CPb3R120/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE1MDU1/My0xMzM0NDE1NDM0/LmpwZWc.jpeg",
-            "sello": "PFG036",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "2003",
-            "estilos": "Deep House, Techno"
-        },
-        "tracklist": [
-            {
-                "nombre": "Entrance 2 The Garden",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "People",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Backagainforthefirsttime?",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "LiveInLA 1998",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "P.B.C.",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Shine",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Yesterdays Party Watta Bout It",
-                "posicion": "C1"
-            },
-            {
-                "nombre": "Silence In The Secret Garden",
-                "posicion": "C2"
-            },
-            {
-                "nombre": "On My Way Home",
-                "posicion": "D1"
-            },
-            {
-                "nombre": "Sweet Yesterday",
-                "posicion": "D2"
-            }
-        ],
-        "artist": {
-            "nombre": "Moodymann",
-            "nombre_real": "unasigned",
-            "perfil": "DJ and producer based in Detroit, Michigan.",
-            "url_imagen": "https://i.discogs.com/PbFRCxt2v2zbQv_kZgOx7fTGKZk41gSB3C64GxR_Sig/rs:fit/g:sm/q:90/h:365/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwOTQt/MTI5MTQ2Mzg5Ni5q/cGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Basic Channel - Octagon / Octaedre",
-            "url_imagen": "https://i.discogs.com/-lKhTTTGZYrRu9B8K8Lb-PWfEbaY2YNWWlqcK88OLVQ/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM1NDMt/MTEyODk0ODU3OS5q/cGVn.jpeg",
-            "sello": "BC 07",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "Germany",
-            "publicado": "1994",
-            "estilos": "Techno, Dub Techno"
-        },
-        "tracklist": [
-            {
-                "nombre": "Octagon",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Octaedre",
-                "posicion": "B"
-            }
-        ],
-        "artist": {
-            "nombre": "Basic Channel",
-            "nombre_real": "unasigned",
-            "perfil": "Basic Channel is a German techno production duo and [url=https://www.discogs.com/label/255-Basic-Channel]record label[/url], composed of Moritz von Oswald and Mark Ernestus, that originated in Berlin in 1993.\r\nThe duo became known in the mid-1990s for a series of vinyl-only releases under various aliases marked by minimalism in both production techniques and graphic esthetics. Basic Channel is widely regarded as a pioneering force of minimal and dub techno.\r\nThe minimalist esthetics of the 12\"s released by the duo / label can lead to ambiguities as to whether the names listed on releases are aliases / project names or just track / release titles, meaning that appearances of those tracks on compilations or DJ mixes were often inconsistently credited.",
-            "url_imagen": "https://i.discogs.com/RKOOdjyBKp8DZ8SII9j9LlPVV3UMFQInyTukmHkgDWY/rs:fit/g:sm/q:90/h:450/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzMTE3/LTEzMTM1OTE4MjMu/anBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Green Velvet - The Stalker",
-            "url_imagen": "https://i.discogs.com/nGfj_TY066bLIvsLA-c6UvZFmdmAznQy6p6Lq4RcFEw/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYyNzkt/MTU4ODE4MDczNy03/MTQ3LmpwZWc.jpeg",
-            "sello": "RR 764",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "US",
-            "publicado": "1996",
-            "estilos": "House, Techno"
-        },
-        "tracklist": [
-            {
-                "nombre": "The Stalker (I'm Losing My Mind)",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Help Me",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Pegal",
-                "posicion": "B2"
-            }
-        ],
-        "artist": {
-            "nombre": "Green Velvet",
-            "nombre_real": "unasigned",
-            "perfil": "American electronic DJ, producer, and artist. \r\n\r\nBorn: 26 April 1968 in Chicago, Illinois, USA. \r\n\r\nGreen Velvet, initially created by house don [a=Cajmere] (AKA [a=Curtis Alan Jones]) as an outlet for his non-vocal productions and frequent DJ-ing gigs, grew to become even more popular than the man himself, thanks to club singles like \"Preacher Man\", \"Answering Machine\", and \"The Stalker\". \r\n\r\nJones, who had nurtured the Chicago house renaissance of the 1990s with his [l=Cajual Records], gained success in 1993 with the [a=Cajmere] single \"Brighter Days\" (with [a=Dajaé] on vocals). Later that year, he formed the sublabel [l=Relief Records], mostly for instrumental tracks by himself and others. \r\n\r\nBesides releases from [a=DJ Sneak], [a=Gemini], and [a=Paul Johnson], Green Velvet figured on many of the early Relief singles, including its first, \"Preacher Man\" as well as \"Flash\" (also released on the British label [l=Open]), \"The Stalker\", and \"Answering Machine\" (1997). \r\n\r\nHe began to supplement his Green Velvet DJ-ing schedule with quasi-live gigs as well, and released his first album in 1999. His self-titled release on label [l=F-111 Records] a year later compiled a dozen of his earlier club hits, and the proper sophomore production album \"Whatever\" (2001) appeared on his own Relief label. \r\n",
-            "url_imagen": "https://i.discogs.com/Uxs1r_JAIYObQYwPQxjOf2FyGjGL0AnaYoXXm6nUgrw/rs:fit/g:sm/q:90/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIxOS0x/Mzk2NDQwNDk4LTI4/ODYuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "FKA Twigs - M3LL155X",
-            "url_imagen": "https://i.discogs.com/OtKvrVvVJkvR_-ed2RThwORVLwcOWcZy3dIgR1Af7FA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc4MDI2/MDAtMTQ0OTA4NTE5/Ny0xOTc0LmpwZWc.jpeg",
-            "sello": "YT142",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "2015",
-            "estilos": "Trip Hop"
-        },
-        "tracklist": [
-            {
-                "nombre": "Figure 8",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "I'm Your Doll",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "In Time",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Glass & Patron",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Mothercreep",
-                "posicion": "B2"
-            }
-        ],
-        "artist": {
-            "nombre": "FKA Twigs",
-            "nombre_real": "unasigned",
-            "perfil": "Tahliah Barnett, born January 16th 1988 in Gloucestershire, is a British musician & dancer.\r\nShe has Jamaican & Spanish roots & currently lives in London, United Kingdom.",
-            "url_imagen": "https://i.discogs.com/rokFNZ7T0w1OFKD7I-Otr9pKtPnAtGkQv_zFVmpei98/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM0NTIx/NTctMTYzOTk0Njcw/MS05NTcwLmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Ed Rush, Optical & Fierce - Cutslo (Lokuste Mix) / Alien Girl",
-            "url_imagen": "https://i.discogs.com/yj1jJwPhEUilwopzrbx2-keieT4T9HNegIYb4PrsmEs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgzMi0x/MzA2NTcwOTUxLmpw/ZWc.jpeg",
-            "sello": "PRO 014",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "1998",
-            "estilos": "Drum n Bass"
-        },
-        "tracklist": [
-            {
-                "nombre": "Cutslo (Lokuste Mix)",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Alien Girl",
-                "posicion": "AA"
-            }
-        ],
-        "artist": {
-            "nombre": "Ed Rush",
-            "nombre_real": "unasigned",
-            "perfil": "Drum n Bass producer based in London. \r\n\r\nHe saved up for his first set of decks whilst working on the fish counter in Sainsburys. His debut DJing gig was at The Brain in London. Linked up with [a=DJ Trace] through Don FM, and [a168579] was his neighbour. This led to them starting to make tracks together, and the eventual formation of No Turn. Also DJed on Flex FM.\r\n\r\nForms the duo [a=Ed Rush & Optical] with [a=Optical] aka [a=Matt Quinn].",
-            "url_imagen": "https://i.discogs.com/3cD7L1xKJEj46MqUkniWg7rLfl0N3uiqDPed8YnFzn0/rs:fit/g:sm/q:90/h:805/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwOC0x/NTQyOTc3Njc5LTY4/NDcuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "X-Press 2 - Muzik Xpress",
-            "url_imagen": "https://i.discogs.com/azD6N3VkZkDd3ewIaRmP57fSa1ExfSC5J5c4fZ5uhV4/rs:fit/g:sm/q:90/h:597/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI0NDA4/LTEyMjM5MDc0NjYu/anBlZw.jpeg",
-            "sello": "JBO 8-12",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK",
-            "publicado": "1992",
-            "estilos": "Progressive House, House"
-        },
-        "tracklist": [
-            {
-                "nombre": "Muzik Xpress",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Muzik Xpress (Double D Mix)",
-                "posicion": "AA1"
-            },
-            {
-                "nombre": "Muzik Xpress (Rock 2 House Beats)",
-                "posicion": "AA2"
-            }
-        ],
-        "artist": {
-            "nombre": "X-Press 2",
-            "nombre_real": "unasigned",
-            "perfil": "British house project.",
-            "url_imagen": "https://i.discogs.com/SqmkoPwKy0vNgi0ii94CFN2d2mvMIXAMgepoa0kZRxk/rs:fit/g:sm/q:90/h:280/w:380/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI5Mzct/MTU0MDk4MDA2My02/OTg3LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Earth People - Dance",
-            "url_imagen": "https://i.discogs.com/qloR_19Kp4WV1ZZmusRLGKyDfqbynqtZGcB_SZ_MhOI/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY2MzAz/LTE1NzYzMjU5MjMt/MjM4NC5qcGVn.jpeg",
-            "sello": "AP 146",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "US",
-            "publicado": "1990",
-            "estilos": "House"
-        },
-        "tracklist": [
-            {
-                "nombre": "Dance (Club Mix)",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Dance (Dub Mix)",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Dance (Beats)",
-                "posicion": "B2"
-            }
-        ],
-        "artist": {
-            "nombre": "Earth People",
-            "nombre_real": "unasigned",
-            "perfil": "",
-            "url_imagen": "https://i.discogs.com/8pxIn1tpGLVNQlBzob1oURgEkaYLD3CdGClNM075oPM/rs:fit/g:sm/q:90/h:472/w:391/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ2MDUt/MTY0NzE2OTU2My0z/NDMzLmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Orbital - Funny Break (One Is Enough)",
-            "url_imagen": "https://i.discogs.com/jyMajzcJeSaTS4dPrKBHv1HMCQwuegv1plKR4zPPWyA/rs:fit/g:sm/q:90/h:587/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQzMjg3/LTEzMDAzMDM2MzMu/anBlZw.jpeg",
-            "sello": "FX395",
-            "formato": "Vinyl",
-            "genero": "Electronic",
-            "pais": "UK & Europe",
-            "publicado": "2001",
-            "estilos": "Breakbeat, Progressive Trance"
-        },
-        "tracklist": [
-            {
-                "nombre": "Funny Break (One Is Enough) (Weekend Ravers Mix)",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Funny Break (One Is Enough) (Plump DJ's Mix)",
-                "posicion": "AA"
-            }
-        ],
-        "artist": {
-            "nombre": "Orbital",
-            "nombre_real": "unasigned",
-            "perfil": "Techno outfit founded in the late 80s by the brothers Paul and Phil Hartnoll.",
-            "url_imagen": "https://i.discogs.com/WMm1pA_Qidl7LjAVGIDb6GiZQKQVqXlHVqbj6Lp9hb4/rs:fit/g:sm/q:90/h:580/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyNzkt/MTY4MDI4NTEwMC01/OTk1LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Jeff Mills - Our Man From Havana",
-            "url_imagen": "https://i.discogs.com/Fo_zv8cN4MfOxTmB_xLba0SRStm2rhlUobmeyVDzmFc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0NS0x/MzA2ODcwMzA1Lmpw/ZWc.jpeg",
-            "sello": "PM-004",
+            "id": 4685,
+            "titulo": "Jeff Mills - Kat Moda EP",
+            "url_imagen": "https://i.discogs.com/Ph1me8FJj4EgukiZPm8VYCsKKnXlpjUZKTfWCry7n0w/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE2NS0x/NDAxMjU0NDAxLTI2/NTIuanBlZw.jpeg",
+            "sello": "PM-002",
             "formato": "Vinyl",
             "genero": "Electronic",
             "pais": "US",
             "publicado": "1997",
-            "estilos": "Techno"
+            "estilos": "Tribal, Techno"
         },
         "tracklist": [
             {
-                "nombre": "The Fly Guy",
+                "nombre": "The Bells",
                 "posicion": "A1"
             },
             {
-                "nombre": "Calypso High",
+                "nombre": "Kat Race",
                 "posicion": "A2"
             },
             {
-                "nombre": "Cubango",
+                "nombre": "Alarms",
                 "posicion": "B1"
             },
             {
-                "nombre": "Sugar Is Sweeter",
+                "nombre": "Cyclone",
                 "posicion": "B2"
             }
         ],
         "artist": {
+            "id": 205,
             "nombre": "Jeff Mills",
             "nombre_real": "unasigned",
             "perfil": "American techno DJ, composer, producer, and recording artist, based in Detroit, Michigan, USA. \r\n\r\nBorn: 18 June 1963 in Detroit, Michigan, USA. \r\n\r\nJeff Mills (aka \"The Wizard\") is one of the most pioneering American names in techno music. Championed for his music's relentless pursuit of hardness and his stripped-down, almost industrial DJ sets, Mills is the latest in a long line of Detroit-bred talent to take on an international reputation, performing for audiences around the world in both club and art spaces. \r\n\r\nHe also runs his own label, [l=Axis], and its several sublabels. Married to [a=Yoko Uozumi].",
@@ -889,130 +39,1031 @@
     },
     {
         "release": {
-            "titulo": "Jimi Hendrix Experience* - Smash Hits",
-            "url_imagen": "https://i.discogs.com/NpVLAExGumG_7TQWVzqQzFLeCkwLOQzrNEdZVRXVOTM/rs:fit/g:sm/q:90/h:531/w:531/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5Njg4/MDMtMTI1NTcxMzY5/Ni5qcGVn.jpeg",
-            "sello": "613004",
+            "id": 67951,
+            "titulo": "SL2 - On A Ragga Tip",
+            "url_imagen": "https://i.discogs.com/fMMKW0JpXU3FUYoygRrZl1bgfGOM2SU9wTSTEyAYKCU/rs:fit/g:sm/q:90/h:589/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEzMDc2/LTE1MTg4ODk2Nzkt/MTQxNS5qcGVn.jpeg",
+            "sello": "XLT-29",
             "formato": "Vinyl",
-            "genero": "Rock",
+            "genero": "Electronic",
             "pais": "UK",
-            "publicado": "1968",
-            "estilos": "Blues Rock, Psychedelic Rock"
+            "publicado": "1992",
+            "estilos": "Breakbeat, Hardcore, Acid"
         },
         "tracklist": [
             {
-                "nombre": "Purple Haze",
+                "nombre": "On A Ragga Tip (Original Mix)",
                 "posicion": "A1"
             },
             {
-                "nombre": "Fire",
+                "nombre": "Pleasure (Original Mix)",
                 "posicion": "A2"
             },
             {
-                "nombre": "The Wind Cries Mary",
+                "nombre": "Changing Trax (Original Mix)",
+                "posicion": "AA1"
+            },
+            {
+                "nombre": "Bassquake (Plus 8 Mix)",
+                "posicion": "AA2"
+            }
+        ],
+        "artist": {
+            "id": 7470,
+            "nombre": "SL2",
+            "nombre_real": "unasigned",
+            "perfil": "Responsible for the [l=Awesome Records] label. Also ran two pirate stations, Awesome FM and Raw FM.",
+            "url_imagen": "https://i.discogs.com/PrZCA9p8KUZhl03yukNvuAgd6Mzpdvu2wz3KGYNtdA8/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTc0NzAt/MTQzNjgxODk5Ny0z/NDA5LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 532828,
+            "titulo": "Thomas Bangalter - Trax On Da Rocks",
+            "url_imagen": "https://i.discogs.com/StfLJ8cKyok6W95ROZJIbnFn2H3LHD2zw2TfH5zNsxY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMwOTkt/MTIzMDE2MDA0OC5q/cGVn.jpeg",
+            "sello": "Roulé 301",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "France",
+            "publicado": "1995",
+            "estilos": "House, Techno, French House"
+        },
+        "tracklist": [
+            {
+                "nombre": "On Da Rocks",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Roulé Boulé",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "What To Do",
                 "posicion": "A3"
             },
             {
-                "nombre": "Can You See Me",
+                "nombre": "Outrun",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Ventura",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 3775,
+            "nombre": "Thomas Bangalter",
+            "nombre_real": "unasigned",
+            "perfil": "French musician, record producer, singer, songwriter, DJ and composer, born 3 January 1975.\r\n\r\nHe is part of the duo [a=Daft Punk]. Son of [a=Daniel Bangalter] AKA [a=Daniel Vangarde], who composed [r=187160] for [a=Ottawan].\r\nAfter the experience of [a=Darlin'] and before the [a=Daft Punk] phenomenon, Thomas Bangalter released the two famous EPs 'Trax On Da Rocks', a composite of various samples set to funky House and Techno beats.\r\n\r\nHe released 'Music Sounds Better With You' on his own label [l=Roulé] as part of [a=Stardust] as well as his remix for \"Rock Shock\" by [a=Roy Davis Jr.].\r\n\r\nIn 1998, his track 'Gym Tonic' was the center of controversy as [a=Bob Sinclar] included it on his album \"Paradise\" without the consent of Bangalter. This resulted in a lawsuit from fitness guru and actress Jane Fonda, whose voice had been illegally sampled on the record.\r\n\r\nA very 'anonymous' person, Bangalter nontheless has given a few interviews in and out of the [a=Daft Punk] phenomenon. Although a lot of people credit him for the invention of 'filtered house', he has cited [a=Carl Craig] AKA [a=Paperclip People] (\"Throw\") and [a=Kenny \"Dope\" Gonzalez] as precursors of the style.\r\nIt must also be noted that outside [a=Daft Punk], Bangalter stopped his DJing career due to ear problems. \r\n\r\nBangalter is married to French actress [a=Elodie Bouchez] with whom he has two sons: Tara-Jay (born 2002) and Roxan (born 2008).",
+            "url_imagen": "https://i.discogs.com/DtOeA4Vdy35Mw_QUFVDVi5ZXc-cB20yRSNascahVa_I/rs:fit/g:sm/q:90/h:450/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM3NzUt/MTY4MDk4NTcyMi0z/NjQxLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 484910,
+            "titulo": "Soul Capsule - Overcome",
+            "url_imagen": "https://i.discogs.com/QoUGDVL4diE2FLsQlWYR3K6OY4a0RwKnTT2RxIK7bhI/rs:fit/g:sm/q:90/h:413/w:420/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU0MzM0/LTExOTY3MzU1NDIu/anBlZw.jpeg",
+            "sello": "TR/11",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1999",
+            "estilos": "Deep House, Tech House, Minimal Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "Overcome",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Lady Science (NYC Sunrise)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Lady Science (Tek Mix)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 98976,
+            "nombre": "Soul Capsule",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/xlzh28C96NQBRXoCRX9mFeDa-KuJ54tE3D4Gwb6Srds/rs:fit/g:sm/q:90/h:396/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk4OTc2/LTE0MDkxOTU3NDUt/NzQ2MC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 157035,
+            "titulo": "Fischerspooner - Emerge",
+            "url_imagen": "https://i.discogs.com/bpPMZeHOFlY6zSNbfBzuvBH0jjPuG4Nw5_Kch65wy2g/rs:fit/g:sm/q:90/h:530/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIyMDQ1/Ny0xNDk0MDk4NjE3/LTkzNDQuanBlZw.jpeg",
+            "sello": "GIGOLO 61",
+            "formato": "CD",
+            "genero": "Electronic",
+            "pais": "Germany",
+            "publicado": "2001",
+            "estilos": "Techno, Electro"
+        },
+        "tracklist": [
+            {
+                "nombre": "Emerge (Radio Edit)",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Emerge (Album Version)",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Emerge (Naughty's Peaktime Mix)",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Emerge (Adult Remix)",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Emerge (Terranova Remix)",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Emerge (Video)",
+                "posicion": "Video"
+            }
+        ],
+        "artist": {
+            "id": 9086,
+            "nombre": "Fischerspooner",
+            "nombre_real": "unasigned",
+            "perfil": "American electroclash duo founded in 1998 in New York City. Warren Fischer and Casey Spooner met each other in Chicago at an art school. ",
+            "url_imagen": "https://i.discogs.com/TGMGNCNHBgJudLtjDPV8LPWAMogCxOLfeNMCdNSAdRw/rs:fit/g:sm/q:90/h:237/w:356/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTkwODYt/MTE2NjAzNDMxMS5q/cGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 17562,
+            "titulo": "Soft Cell - Say Hello, Wave Goodbye",
+            "url_imagen": "https://i.discogs.com/RRmifbWFABcP6_A5jUVwRR7PDFCak_p6sLCMKIqW6Gc/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEzNTcx/NS0xMjc3OTc1NzE4/LmpwZWc.jpeg",
+            "sello": "BZS 7",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1982",
+            "estilos": "Synth-pop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Say Hello, Wave Goodbye",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Say Hello, Wave Goodbye (Instrumental)",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "id": 12196,
+            "nombre": "Soft Cell",
+            "nombre_real": "unasigned",
+            "perfil": "Soft Cell are an English synthesizer duo, consisting of Marc Almond (vocals) and David Ball (keyboards), who came to prominence in the early 1980s. \r\nTheir lyrics often focus on love and romance as well as the darker side of life, with subjects such as the nightlife, kinky sex, transvestism, drugs and murder. They had a huge world-wide hit in 1981 with a cover version of \"Tainted Love,\" a northern soul classic originally sung by [a=Gloria Jones] (the wife of [a=Marc Bolan]), that they followed up with more charting singles and one of the first remix Albums \"Non-Stop Ecstatic Dancing.\"  Their self-penned non-album single \"[m=4349],\" missed the No.1 spot of the UK charts by a hairbreadth. \r\n\r\n\"The Art Of Falling Apart',\" produced with Mike Thorne and the then new CMI Fairlight at hand with endless efforts by Dave Ball aiming at perfection followed in 1982. It spawned two singles chosen against the will of the record companies; \"Where The Heart Is,\" and \"Numbers,\" the first on youthful frustration, the later about frequently changing sexual partners and neither sold too well. \r\n\r\nThe commercial pressure finally collided with their artistic ambitions which led to solo and side projects and two farewell shows in January 1984 even before \"This Last Night In Sodom,\" was released. \r\n\r\nThey reunited in the early 2000's and toured with a 4th studio album \"Cruelty Without Beauty,\" following in 2002. Once again they reunited for a final well documented \"[m=1583486],\" live show in 2018 and the recording of a new single.\r\n\r\nTheir new studio album \"*Happiness Not Included,\" was released in spring of 2022.\r\n\r\n",
+            "url_imagen": "https://i.discogs.com/MCpZTWcFqJOj4MGo2qVJY5RMEontVq_44qV0OLDwNDM/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyMTk2/LTE1Nzc4OTY1OTAt/OTIxNy5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 21405,
+            "titulo": "Richie Hawtin - Minus Orange",
+            "url_imagen": "https://i.discogs.com/NAJD5NsxaSDxYkXAYiSHyuKGB_u4c5ibZXCi2Qurl5s/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMwMDkz/OTEtMTU1NDI4NjA1/Ni04NjU2LmpwZWc.jpeg",
+            "sello": "M_NUS ORANGE",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "Canada",
+            "publicado": "1999",
+            "estilos": "Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "Untitled",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Untitled",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Untitled",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Untitled",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 835,
+            "nombre": "Richie Hawtin",
+            "nombre_real": "unasigned",
+            "perfil": "Canadian (British born) producer, label manager and DJ, born June 4, 1970; brother of [a185883]. \r\n\r\nAlthough mainly influenced by Detroit techno, Hawtin has developed his own style ranging from harder noisy techno to deep minimal abstract acid, particularly under his best known alias Plastikman. He was involved in the development of the Final Scratch digital DJ technology and has continued to use new technology as it becomes available.\r\n\r\nFounded the [l=Plus 8 Records], [l=M_nus] and [l=Probe Records] techno labels.\r\n\r\nBefore becoming a DJ worked in a video game shop & at McDonald's.",
+            "url_imagen": "https://i.discogs.com/9tFFDcscxDCf1ptrA2RRnASPWRXGQ7VmHE3zGIiT-xU/rs:fit/g:sm/q:90/h:743/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTgzNS0x/NTE3NjcyNTEwLTY4/NDguanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 1231184,
+            "titulo": "Bicep - Bicep",
+            "url_imagen": "https://i.discogs.com/-wto36WfY_hB-CS337CJ8zIOVE97dRthvfVut3qscXQ/rs:fit/g:sm/q:90/h:532/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNzk3/NTQyLTE2NTI4Mzkx/MTctMjkwMS5qcGVn.jpeg",
+            "sello": "ZENCD244",
+            "formato": "CD",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2017",
+            "estilos": "House, Techno, Trance"
+        },
+        "tracklist": [
+            {
+                "nombre": "Orca",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Glue",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Kites",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Vespa",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Ayaya",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Spring",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Drift",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Opal",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Rain",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Ayr",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Vale",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Aura",
+                "posicion": "12"
+            }
+        ],
+        "artist": {
+            "id": 1540289,
+            "nombre": "Bicep",
+            "nombre_real": "unasigned",
+            "perfil": "DJ and production duo from Belfast, Northern Ireland. Composed of [a=Andrew Ferguson (3)] & [a=Matthew McBriar].\r\nTogether with [a=Hammer] (aka [a=Rory Hamilton]), they run the music repository [l=Feel My Bicep].",
+            "url_imagen": "https://i.discogs.com/kZgNbMiqbqkwnP3qzAbr8_8tIDlcbFvJcrXp9m9l0vM/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE1NDAy/ODktMTYwMjAxNTc4/NC05ODMxLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 77702,
+            "titulo": "Moodymann - I Can't Kick This Feelin When It Hits / Music People",
+            "url_imagen": "https://i.discogs.com/L2YHgDHRpCDePfISsixaT3wA6-u6hIleFvCkoG9LZ9E/rs:fit/g:sm/q:90/h:395/w:395/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY1NzYt/MDAyLmpwZw.jpeg",
+            "sello": "KDJ 6",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1996",
+            "estilos": "House, Deep House"
+        },
+        "tracklist": [
+            {
+                "nombre": "I Can't Kick This Feelin When It Hits",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Music People",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "id": 1094,
+            "nombre": "Moodymann",
+            "nombre_real": "unasigned",
+            "perfil": "DJ and producer based in Detroit, Michigan.",
+            "url_imagen": "https://i.discogs.com/PbFRCxt2v2zbQv_kZgOx7fTGKZk41gSB3C64GxR_Sig/rs:fit/g:sm/q:90/h:365/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwOTQt/MTI5MTQ2Mzg5Ni5q/cGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 19527,
+            "titulo": "Herbie Hancock - Sound-System",
+            "url_imagen": "https://i.discogs.com/Y1Z2rQtswNKrRKcijHkMK14gtp_GKB_CBgcpseyUJrY/rs:fit/g:sm/q:90/h:589/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMxMzgz/LTE1NDk5MjU5MzIt/NDQ5MC5qcGVn.jpeg",
+            "sello": "FC 39478",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1984",
+            "estilos": "Electro"
+        },
+        "tracklist": [
+            {
+                "nombre": "Hardrock",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Metal Beat",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Karabali",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Junku",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "People Are Changing",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Sound-System",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "id": 3865,
+            "nombre": "Herbie Hancock",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz pianist, keyboardist, composer, band leader born April 12, 1940, in Chicago, Illinois, USA.\r\nHancock is one of the best-known modern jazz composers, creator of “Watermelon Man” (which has been a reference point throughout his career), “Maiden Voyage”, “Dolphin Dance”, right through to the dance grooves of “[r=3173760]”.",
+            "url_imagen": "https://i.discogs.com/FsPFfIQgWkq60J41ShsFZG0B0kBu0xAFIbo8kx_m9Ys/rs:fit/g:sm/q:90/h:350/w:414/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM4NjUt/MTEwNTk4NjY3Mi5q/cGc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 12254,
+            "titulo": "The Prodigy - One Love",
+            "url_imagen": "https://i.discogs.com/gxK41Iwpfv4iHyat2dhNL2yJkwvXpV6-jXhfm3ueZBc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc0NjMt/MTYzMDc1NTQ3NS00/ODU3LmpwZWc.jpeg",
+            "sello": "XLT 47",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1993",
+            "estilos": "Breakbeat, Hardcore, Techno"
+        },
+        "tracklist": [
+            {
+                "nombre": "One Love (Original Mix)",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Rhythm Of Life (Original Mix)",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Full Throttle (Original Mix)",
+                "posicion": "AA1"
+            },
+            {
+                "nombre": "One Love (Jonny L Remix)",
+                "posicion": "AA2"
+            }
+        ],
+        "artist": {
+            "id": 66852,
+            "nombre": "The Prodigy",
+            "nombre_real": "unasigned",
+            "perfil": "British electronic group, founded in 1990. Their first release was \"What Evil Lurks\" EP (1991). Their early music was mostly rave/breakbeat, but has become more mainstream mixing in rock guitars with the third album \"The Fat Of The Land\" (1997).\r\n\r\nBand members:\r\n[a=Liam Howlett] - head of the group, keyboards, synthesizers, programming, laptop, computer, samples, sequencers, turntables, drum machines (1990-present)\r\n[a=Maxim] - MC, beatboxing, vocals (1991-present)\r\n\r\nFormer members:\r\n[a=Keith Flint] - dancing (1990-2019); lead vocals (1995-2019)\r\n[a=Leeroy Thornhill] - dancing (1990-2000); occasional live keyboards, synthesizers (1994-2000)\r\nSharky - dancing (1990-1991)\r\n\r\nThe original Prodigy line-up was Liam on keyboards and Leeroy, Keith and Sharky as dancers, formed in late 1990 (The Prodigy officially name the date October 5, 1990). Maxim was recruited at short notice to MC at their debut gig at Labrynth in Dalston, London in February 1991. Sharky left the group at Christmas 1990 after they got their record deal with XL as she didn't want to devote more time to the band. Their initial deal with XL was for 4 singles, with XL paying a £1500 advance prior to the first single.\r\nLiam Howlett briefly used the pseudonym [a=Earthbound (6)] (named after Liam's studio) for the original white-label summer releases of \"One Love\" (1993).\r\n[a=Leeroy Thornhill] left the band in 2000. \r\nKeith Flint died by suicide on 4 March 2019.",
+            "url_imagen": "https://i.discogs.com/tCjMDcvXIXBD-UgvA6zzX9WwOMGbwft_6nPl-9ZRGJI/rs:fit/g:sm/q:90/h:394/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY2ODUy/LTE2ODUxMTU1OTMt/ODI1MC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 36425,
+            "titulo": "Tricky Disco - Tricky Disco",
+            "url_imagen": "https://i.discogs.com/igpPxX3TttdTUG8luw4gvnJAR-3yjMECC8jcicHMYRU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI0NjYt/MTMwOTA4MjA5MC5q/cGVn.jpeg",
+            "sello": "WAP 7",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1990",
+            "estilos": "House, Techno, Bleep"
+        },
+        "tracklist": [
+            {
+                "nombre": "Tricky Disco",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Tricky Disco (Past Tricky's Bedtime Mix)",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "id": 2914,
+            "nombre": "Tricky Disco",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/l75cx8eSCUQldpaAFRJN-1kOVEOQwm28vLo_j75u1z8/rs:fit/g:sm/q:90/h:334/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI5MTQt/MTEwOTA5NTIxNi5q/cGc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 2394,
+            "titulo": "Bonobo - Animal Magic",
+            "url_imagen": "https://i.discogs.com/1pd8AxOoD1eIE__W5SC4PqsQTZfYm1Uh8fc8G_QkyYA/rs:fit/g:sm/q:90/h:603/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0MzYt/MTI0NjkwNjc2Mi5q/cGVn.jpeg",
+            "sello": "TRU CD 007",
+            "formato": "CD",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2000",
+            "estilos": "Future Jazz, Downtempo"
+        },
+        "tracklist": [
+            {
+                "nombre": "Intro",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Sleepy Seven",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Dinosaurs",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Kota",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Terrapin",
+                "posicion": "5"
+            },
+            {
+                "nombre": "The Plug",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Shadowtricks",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Gypsy",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Sugar Rhyme",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Silver",
+                "posicion": "10"
+            }
+        ],
+        "artist": {
+            "id": 8708,
+            "nombre": "Bonobo",
+            "nombre_real": "unasigned",
+            "perfil": "[a=Simon Green (2)] (born 30 March 1976), known by his stage name Bonobo, is a British musician, producer and DJ based in Los Angeles. He debuted with a trip-hop aesthetic, and has since explored more upbeat approaches while experimenting with jazz and world music. His electronic sound incorporates the use of organic instrumentation, and is recreated by a full band during his live performances.\r\n\r\nIn 2020 founded his own [l=OUTLIER] label.",
+            "url_imagen": "https://i.discogs.com/JkKwnyVBYbQGSJA5j79B5NGtwSmgKL4ADjTyLcb03Z0/rs:fit/g:sm/q:90/h:617/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTg3MDgt/MTYzNjU4MDc5OC04/NDk4LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 34572,
+            "titulo": "Scott Grooves Featuring Parliament / Funkadelic - Mothership Reconnection",
+            "url_imagen": "https://i.discogs.com/9A7a6_N9Q0KUU4g91eCutaYr5dJk41GB3RsYiebNg-c/rs:fit/g:sm/q:90/h:610/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgwODgt/MTQ5MzA3NDkxNS0y/MDQzLnBuZw.jpeg",
+            "sello": "SOMA 71",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1998",
+            "estilos": "House, Tech House, Disco"
+        },
+        "tracklist": [
+            {
+                "nombre": "Mothership Reconnection (Original)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "Mothership Reconnection (Daft Punk Remix)",
+                "posicion": "AA1"
+            }
+        ],
+        "artist": {
+            "id": 7606,
+            "nombre": "Scott Grooves",
+            "nombre_real": "unasigned",
+            "perfil": "Detroit based house & techno producer.\r\nScored a club classic hit with \"Mothership Reconnection\" in 1998.\r\nHe has been working very independently since early 2000 releasing mostly on his own imprints [l=Natural Midi], [l=Modified Suede Recordings] and [l=From The Studio Of Scott Grooves].\r\n\r\nUsed to play keyboards for [a=Inner City].",
+            "url_imagen": "https://i.discogs.com/FGBidKgmZIee25VFg29jQRIw1XeCI1vXIHE2_w_HIrk/rs:fit/g:sm/q:90/h:267/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTc2MDYt/MTQwMjY1Nzk1MC00/ODgyLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 116373,
+            "titulo": "Nightmares On Wax - In A Space Outta Sound",
+            "url_imagen": "https://i.discogs.com/JqYcQuvOAJ7JwQOE65YbUbP9Wg0aQQO5laphnffTvaw/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYzNzc3/NC0xMTg5MjQ4MDEx/LmpwZWc.jpeg",
+            "sello": "WARP CD133",
+            "formato": "CD",
+            "genero": "Electronic",
+            "pais": "UK, Europe & US",
+            "publicado": "2006",
+            "estilos": "Downtempo, Trip Hop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Passion",
+                "posicion": "1"
+            },
+            {
+                "nombre": "The Sweetest",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Flip Ya Lid",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Pudpots",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Damn",
+                "posicion": "5"
+            },
+            {
+                "nombre": "You Wish",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Deepdown",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Chime Out",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Me!",
+                "posicion": "9"
+            },
+            {
+                "nombre": "I Am You",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Soul Purpose",
+                "posicion": "11"
+            },
+            {
+                "nombre": "African Pirates",
+                "posicion": "12"
+            }
+        ],
+        "artist": {
+            "id": 759,
+            "nombre": "Nightmares On Wax",
+            "nombre_real": "unasigned",
+            "perfil": "The longest serving artist on the Warp Records roster. Originally founded in 1988 by George \"DJ E.A.S.E.\" Evelyn and Kevin \"Boywonder\" Harper. Harper left before the release of Smokers Delight. When playing live they were also joined by MC Toz 180 and guitarist Chris Dawkins.",
+            "url_imagen": "https://i.discogs.com/U-RtvXhOB9mitoliWU-R4-8x9jD3DnlnqBs1BM-MRro/rs:fit/g:sm/q:90/h:220/w:220/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTc1OS0x/MzIxNjM3MDIyLmpw/ZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 94693,
+            "titulo": "Junior Jack - E Samba",
+            "url_imagen": "https://i.discogs.com/n1LmeuU-07QlR_6GHw9Y1d1jrsnYheV8w0HK8f9Lg9w/rs:fit/g:sm/q:90/h:550/w:550/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE1NDkw/NS0xMTQ3ODAzMjM3/LmpwZWc.jpeg",
+            "sello": "PIASB 107 T",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "Belgium",
+            "publicado": "2003",
+            "estilos": "House"
+        },
+        "tracklist": [
+            {
+                "nombre": "E Samba (JJ Original Club Mix)",
+                "posicion": "A"
+            },
+            {
+                "nombre": "E Samba (Full Intention Main Mix)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "E Samba (Full Intention Club Mix)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 4266,
+            "nombre": "Junior Jack",
+            "nombre_real": "unasigned",
+            "perfil": "Italian DJ and producer, born in Rutigliano 31 August 1971 but grew up in Belgium. He started his music career in 1990.",
+            "url_imagen": "https://i.discogs.com/fYd_EQiTEje_Ukt-mBWvYoqVswMRbfEtEZlyehySqD4/rs:fit/g:sm/q:90/h:902/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQyNjYt/MTIxMjkzNDkwOS5q/cGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 15730,
+            "titulo": "Nathan Fake - The Sky Was Pink",
+            "url_imagen": "https://i.discogs.com/sULi9Q9VBCvJQhoGRvWB2Gh5BKZO2SsPopcLFSY7e8Y/rs:fit/g:sm/q:90/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMxNDQ0/OS0xMzIxODExMDAx/LmpwZWc.jpeg",
+            "sello": "06BC",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2004",
+            "estilos": "Leftfield, Progressive House, IDM, Downtempo, Minimal"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Sky Was Pink (Original Live Take)",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "The Sky Was Pink (Icelandic Version)",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "The Sky Was Pink (Holden Remix)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "The Sky Was Pink (Holden Tool)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 137792,
+            "nombre": "Nathan Fake",
+            "nombre_real": "unasigned",
+            "perfil": "British electronic musician and producer (b. 3 March 1983, King's Lynn, Norfolk). Nathan Fake produced five full-length albums, numerous EPs and remix commissions. He's been signed by [l=Ninja Tune] since 2016 and lives and works in Norwich. Fake's latest long-playing record, [i][m=1720532][/i] CD/2xLP, came out in April 2020 via [b][l=Cambria Instruments][/b] label, which Nathan co-founded in 2014.\r\n\r\nNathan Fake grew up in Norfolk and began making music in high school, inspired by IDM acts like [a=Aphex Twin] and [a=Orbital] on the radio and further reading about the artists and their gear in music magazines. In 2003, Nathan met [a=James Holden], who signed an aspiring producer on his [b][l=Border Community][/b] label, releasing [i][r=193039][/i] 12\" EP. More records soon followed on [a=Satoshi Tomiie]'s US-based [l=Saw Recordings], [l=Traum Schallplatten] in Cologne, Germany, and [l=Electrochoc Records] in France. Nathan Fake continued working with Border Community, producing two more EPs in 2004–05, leading to his debut full-length studio album, [i][m=24253][/i] 2x12\"/CD, in March 2006. The record gained positive reviews from [url=https://discogs.com/label/183279]Pitchfork[/url], [l=The Guardian], and other publications; [l=Mixmag] mentioned it on the list of top albums of the year.\r\n\r\nIn 2014, Nathan Fake co-founded [b][l=Cambria Instruments][/b] with [a=Wesley Matsell], fellow Border Community alumni. Inaugurated with their [i][r=5991338][/i] split 12\" in August, the new imprint soon presented Nathan's solo [i][r=6610991][/i] 12\" EP. As a prolific remix producer, Nathan Fake has collaborated with major and independent acts and labels, from [a=Radiohead] to [a=Jon Hopkins] and [a=Chris Clark], [l69345], [l=Warp Records], and [l=Kompakt].\r\n\r\nIn September 2016, one of the leading UK electronic labels, [l=Ninja Tune], signed Nathan Fake and released his [i][r=9442223][/i] 12\" EP later the same year. He released the fourth long-playing album, [i][m=1148009][/i] 2xLP/CD, in the spring of 2017, featuring [a=Prurient] (founder of [a=Hospital Productions]) and [a=Raphaelle Standell-Preston] (of [a=Braids]) as guest musicians. This record further strengthened Fake's reputation, with favorable media coverage from [l98607] and [l=Wire Magazine] and such accolades as DJ Mag's \"Album of the Month\" or [url=https://discogs.com/label/153965]Bleep[/url]'s \"Album of the Week.\" A few notable DJs who supported Fake's tracks were [a=Ben UFO] and [a=Helena Hauff]. Later that year, Ninja Tune released a two-part [i]Providence Reworks[/i] with remixes from [a=Overmono], [a=Huerco S.], [a=Olga Wojciechowska] and [a=Konx-Om-Pax].",
+            "url_imagen": "https://i.discogs.com/kh-MaOGuyEAmOlpHrCfVtWoX5dYzERt3NocteoIuBe0/rs:fit/g:sm/q:90/h:739/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzNzc5/Mi0xNTcxODIyNzQ4/LTc3MzUuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 15281,
+            "titulo": "Cassius - Feeling For You",
+            "url_imagen": "https://i.discogs.com/POXc-e5f2LJISDGBQ4dfxmh4O3jWlopmbKtMlw5UZwA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ0NDQt/MTIwNjg5Nzg4My5q/cGVn.jpeg",
+            "sello": "ASW 6263-6",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "US",
+            "publicado": "1999",
+            "estilos": "House"
+        },
+        "tracklist": [
+            {
+                "nombre": "Feeling For You (Les Rhythmes Digitales-Dreamix)",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Feeling For You (DJ Tool Short Mix)",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Feeling For You (Cambridge Circus Mix)",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Cassius 99 Remix (Full Length Version)",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 3358,
+            "nombre": "Cassius",
+            "nombre_real": "unasigned",
+            "perfil": "Former French duo based in Paris which broke up in 2019 with the death of [a12646].\r\nFounders of label [l=Cassius Records].",
+            "url_imagen": "https://i.discogs.com/GRgnPfcxW1fSRnD499JHaf5O4awBg7XAPVuL1zqB59I/rs:fit/g:sm/q:90/h:513/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMzNTgt/MTYxMzg1NzY0MS00/ODY3LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 6223,
+            "titulo": "Moodymann - Forevernevermore",
+            "url_imagen": "https://i.discogs.com/cj1gmb5-vdegg4H1ME-c9vURocm_oD9yG4KuIebXFag/rs:fit/g:sm/q:90/h:225/w:225/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwMTUt/MDAyLmpwZw.jpeg",
+            "sello": "PF 095",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "2000",
+            "estilos": "Deep House"
+        },
+        "tracklist": [
+            {
+                "nombre": "Meanwhile Back At Home",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Wednesday Night People",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "The Set Up",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Don't You Want My Love",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "(Logo)",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Your Sweet Lovin",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "The Thief That Stole My Sad Days (Ya Blessin Me)",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "Forevernevermore",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "Tribute",
+                "posicion": "D2"
+            }
+        ],
+        "artist": {
+            "id": 1094,
+            "nombre": "Moodymann",
+            "nombre_real": "unasigned",
+            "perfil": "DJ and producer based in Detroit, Michigan.",
+            "url_imagen": "https://i.discogs.com/PbFRCxt2v2zbQv_kZgOx7fTGKZk41gSB3C64GxR_Sig/rs:fit/g:sm/q:90/h:365/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwOTQt/MTI5MTQ2Mzg5Ni5q/cGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 30010,
+            "titulo": "Various - Artificial Intelligence",
+            "url_imagen": "https://i.discogs.com/mb10_kburEOKnl2FcaDwL6tTNYa10jyfuZT7EjF2MNA/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI5Mzcy/LTE2MjA2NTE3MzEt/ODE1OC5qcGVn.jpeg",
+            "sello": "WARP LP6",
+            "formato": "Vinyl",
+            "genero": "Electronic",
+            "pais": "UK",
+            "publicado": "1992",
+            "estilos": "IDM, Downtempo, Ambient"
+        },
+        "tracklist": [
+            {
+                "nombre": "Polygon Window",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Telefone 529",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Crystel",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "The Clan",
                 "posicion": "A4"
             },
             {
-                "nombre": "51st Anniversary",
+                "nombre": "De-Orbit",
                 "posicion": "A5"
             },
             {
-                "nombre": "Hey Joe",
-                "posicion": "A6"
-            },
-            {
-                "nombre": "Stone Free",
+                "nombre": "Preminition",
                 "posicion": "B1"
             },
             {
-                "nombre": "The Stars That Play With Laughing Sam's Dice",
+                "nombre": "Spiritual High",
                 "posicion": "B2"
             },
             {
-                "nombre": "Manic Depression",
+                "nombre": "The Egg",
                 "posicion": "B3"
             },
             {
-                "nombre": "Highway Chile",
+                "nombre": "Loving You Live",
                 "posicion": "B4"
-            },
-            {
-                "nombre": "The Burning Of The Midnight Lamp",
-                "posicion": "B5"
-            },
-            {
-                "nombre": "Foxy Lady",
-                "posicion": "B6"
             }
         ],
         "artist": {
-            "nombre": "The Jimi Hendrix Experience",
+            "id": 1094,
+            "nombre": "Moodymann",
             "nombre_real": "unasigned",
-            "perfil": "The Jimi Hendrix Experience (often shortened to The Experience) was a band comprising guitarist/singer/songwriter [a110593], bassist/backing vocalist/songwriter [a252848], and drummer/backing vocalist [a252849]. Formed in London, England in October 1966 by ex-Animals bassist [a254160], The Experience were active for just under three years, a run which resulted in three successful studio albums and four top 10 singles.",
-            "url_imagen": "https://i.discogs.com/N4_Cs1TMOq2yDmo4FgRSxxzKa_xRXFjI_mJ2mOnK6ao/rs:fit/g:sm/q:90/h:455/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1NTY3/Mi0xNjQ0Mzg3Nzky/LTY1MzAuanBlZw.jpeg"
+            "perfil": "DJ and producer based in Detroit, Michigan.",
+            "url_imagen": "https://i.discogs.com/PbFRCxt2v2zbQv_kZgOx7fTGKZk41gSB3C64GxR_Sig/rs:fit/g:sm/q:90/h:365/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEwOTQt/MTI5MTQ2Mzg5Ni5q/cGVn.jpeg"
         }
     },
     {
         "release": {
-            "titulo": "Van Halen - Fair Warning",
-            "url_imagen": "https://i.discogs.com/aEFOJOTH443ENG-3q_y0maWK_nP738rf4WAEVN-BctE/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwODA1/NjUtMTM1ODM4NDcy/NS05Nzk4LmpwZWc.jpeg",
-            "sello": "HS 3540",
+            "id": 20048,
+            "titulo": "The Smiths - Hatful Of Hollow",
+            "url_imagen": "https://i.discogs.com/oJ85N6HJOBPwHlzIUJpersJGDpAhO9zXYt__ulYOJSY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM4MjEz/NS0xNjY4MTM5NDE5/LTk5NjguanBlZw.jpeg",
+            "sello": "ROUGH 76",
             "formato": "Vinyl",
             "genero": "Rock",
-            "pais": "US",
-            "publicado": "1981",
-            "estilos": "Hard Rock, Heavy Metal"
+            "pais": "UK",
+            "publicado": "1984",
+            "estilos": "Alternative Rock, Indie Rock"
         },
         "tracklist": [
             {
-                "nombre": "Mean Street",
+                "nombre": "William, It Was Really Nothing",
                 "posicion": "A1"
             },
             {
-                "nombre": "\"Dirty Movies\"",
+                "nombre": "What Difference Does It Make?",
                 "posicion": "A2"
             },
             {
-                "nombre": "Sinner's Swing!",
+                "nombre": "These Things Take Time",
                 "posicion": "A3"
             },
             {
-                "nombre": "Hear About It Later",
+                "nombre": "This Charming Man",
                 "posicion": "A4"
             },
             {
-                "nombre": "Unchained",
+                "nombre": "How Soon Is Now?",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Handsome Devil",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Hand In Glove",
+                "posicion": "A7"
+            },
+            {
+                "nombre": "Still Ill",
+                "posicion": "A8"
+            },
+            {
+                "nombre": "Heaven Knows I'm Miserable Now",
                 "posicion": "B1"
             },
             {
-                "nombre": "Push Comes To Shove",
+                "nombre": "This Night Has Opened My Eyes",
                 "posicion": "B2"
             },
             {
-                "nombre": "So This Is Love?",
+                "nombre": "You've Got Everything Now",
                 "posicion": "B3"
             },
             {
-                "nombre": "Sunday Afternoon In The Park",
+                "nombre": "Accept Yourself",
                 "posicion": "B4"
             },
             {
-                "nombre": "One Foot Out The Door",
+                "nombre": "Girl Afraid",
                 "posicion": "B5"
+            },
+            {
+                "nombre": "Back To The Old House",
+                "posicion": "B6"
+            },
+            {
+                "nombre": "Reel Around The Fountain",
+                "posicion": "B7"
+            },
+            {
+                "nombre": "Please Please Please Let Me Get What I Want",
+                "posicion": "B8"
             }
         ],
         "artist": {
-            "nombre": "Van Halen",
+            "id": 83080,
+            "nombre": "The Smiths",
             "nombre_real": "unasigned",
-            "perfil": "American rock band formed in Pasadena, California in 1974 by Dutch brothers Eddie and Alex Van Halen. From 1974 until 1985, the band consisted of the Van Halens (guitar and drums, respectively); vocalist David Lee Roth; and bassist/vocalist Michael Anthony. In 1985, Roth left the band to embark on a solo career and was replaced by former Montrose lead vocalist Sammy Hagar. With Hagar, the group released four  albums over the course of 11 years. Former Extreme frontman Gary Cherone replaced Hagar in 1996, before parting ways in 1999. Van Halen then went on hiatus until reuniting with Hagar in 2003 for a worldwide tour in 2004. Hagar again left Van Halen in 2005. In 2006 Roth returned, but Anthony was replaced on bass guitar by Eddie's son, Wolfgang Van Halen. In 2012, the band released their final studio album. It was also Van Halen's first album with Roth in 28 years and the only one to feature Wolfgang. \r\n\r\n[a211671] died on the 6th October 2020 at St. Johns Hospital, Santa Monica, California after a long battle with throat cancer.",
-            "url_imagen": "https://i.discogs.com/4WwTrwoISipufS1BmrZVJuCo4QCPOhie0CaLWtkHsKA/rs:fit/g:sm/q:90/h:414/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk0MDY2/LTE2Mjc2NjA0Nzgt/MjI2Ny5qcGVn.jpeg"
+            "perfil": "The Smiths were an English rock band formed in Manchester in 1982. The group consisted of vocalist Morrissey, guitarist Johnny Marr, bassist Andy Rourke, and drummer Mike Joyce. Critics have called them one of the most important bands to emerge from the British independent music scene of the 1980s. In 2002, the NME named the Smiths \"the artist to have had the most influence on the NME\". In 2003, all four of their albums appeared on Rolling Stone's list of the \"500 Greatest Albums of All Time\".  The band broke up in 1987 due to internal tensions and have turned down several offers to reunite.\r\n\r\nFinal lineup:\r\nMorrissey – lead vocals, percussion (1982–1987)\r\nMike Joyce – drums (1982–1987)\r\nAndy Rourke – bass (1982–1986, 1986-1987)\r\nIvor Perry – guitars (1987)\r\n\r\nFormer members\r\nJohnny Marr – guitars, piano, keyboards, harmonica (1982–1987)\r\nSteven Pomfret – guitars (1982)\r\nDale Hibbert – bass (1982)\r\nJames Maker – dancing, maracas, backing vocals (1982–1983)\r\nCraig Gannon – bass (1986), guitars (1986)\r\n\r\nSession and touring members:\r\nSimon Wolstencroft – drums (1982)\r\nGuy Pratt – bass (1986)",
+            "url_imagen": "https://i.discogs.com/lx3OGm_95ffs_PsdTwdNFdkIPvhly6VVlSSUNCLghkE/rs:fit/g:sm/q:90/h:480/w:567/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTgzMDgw/LTEzMTgxNTY5NjUu/anBlZw.jpeg"
         }
     },
     {
         "release": {
+            "id": 35199,
+            "titulo": "Yes - Going For The One",
+            "url_imagen": "https://i.discogs.com/0A8U3jH7CYusOqdX5WG9iEFYKpxUz9azvftm8Y15xG0/rs:fit/g:sm/q:90/h:586/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU5ODI3/Ny0xMzk2NjMzMjI3/LTU3MTEuanBlZw.jpeg",
+            "sello": "K 50379",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "UK",
+            "publicado": "1977",
+            "estilos": "Prog Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "Going For The One",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Turn Of The Century",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Parallels",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Wonderous Stories",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Awaken",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 50263,
+            "nombre": "Yes",
+            "nombre_real": "unasigned",
+            "perfil": "Yes are an English rock band who achieved worldwide success with their progressive, art, and symphonic style of rock music. Regarded as one of the pioneers of the progressive genre, Yes are known for their lengthy songs, mystical lyrics, elaborate album art, and live stage sets. No fewer than 18 musicians have been a part of the band's line-up, with its current form comprising singer [a=Jon Davison], bassist [a=Billy Sherwood], guitarist [a=Steve Howe], keyboardist [a=Geoff Downes], and drummer [a=Jay Schellen].",
+            "url_imagen": "https://i.discogs.com/iHvbRzu26BnDxUYpG2B1wUkbQUSN5xkjk0RYydXn_nQ/rs:fit/g:sm/q:90/h:766/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTUwMjYz/LTE1MDEyOTgyNjIt/NTkwOS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 268496,
+            "titulo": "Tame Impala - Innerspeaker",
+            "url_imagen": "https://i.discogs.com/i3rsD0HQ6wa4CPQGRcSa5Zc_K-jRogPC3wp4jCd-OU8/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI0MDI3/MjAtMTU0NzQ0ODA5/Mi0yMTMyLmpwZWc.jpeg",
+            "sello": "MODVL128",
+            "formato": "Vinyl",
+            "genero": "Rock",
+            "pais": "Australia",
+            "publicado": "2010",
+            "estilos": "Psychedelic Rock"
+        },
+        "tracklist": [
+            {
+                "nombre": "It Is Not Meant To Be",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Desire Be Desire Go",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Alter Ego",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Lucidity",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Why Won't You Make Up Your Mind?",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Solitude Is Bliss",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Jeremy's Storm",
+                "posicion": "C1"
+            },
+            {
+                "nombre": "Expectation",
+                "posicion": "C2"
+            },
+            {
+                "nombre": "The Bold Arrow Of Time",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "Runway, Houses, City, Clouds",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "I Don't Really Mind",
+                "posicion": "D2"
+            }
+        ],
+        "artist": {
+            "id": 1245513,
+            "nombre": "Tame Impala",
+            "nombre_real": "unasigned",
+            "perfil": "Tame Impala is the psychedelic rock project of [a1245512] in the studio, but as a touring act from 2007, Parker plays alongside [a1007517], [a1245514], [a819641] and [a3413307]. The band released their critically acclaimed debut album [m268496], which achieved certified Gold in Australia. The follow up was 2012's [m477610] receiving a Grammy nomination for Best Alternative Music Album. A third album released in 2015, [m861083], won ARIA Awards for 'Best Rock Album' and 'Album of the Year'.",
+            "url_imagen": "https://i.discogs.com/_pZNESCaPzf9bTXRrZjabJO9w0spkDk0q2XRaSnihXY/rs:fit/g:sm/q:90/h:400/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyNDU1/MTMtMTQ2NjQ5MTkz/OC04NDAxLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 729401,
             "titulo": "My Chemical Romance - Three Cheers For Sweet Revenge",
             "url_imagen": "https://i.discogs.com/HAglwKeMK095cuf0Vo4Ub2u21tmpw2c8LGYtcFjza_4/rs:fit/g:sm/q:90/h:475/w:475/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUzMzky/Mi0xMTI4NTQ0Mzgz/LmpwZWc.jpeg",
             "sello": "48615-2",
@@ -1077,6 +1128,7 @@
             }
         ],
         "artist": {
+            "id": 319406,
             "nombre": "My Chemical Romance",
             "nombre_real": "unasigned",
             "perfil": "My Chemical Romance is an American rock band from New Jersey, formed in 2001. The band consists of lead vocalist Gerard Way, guitarists Ray Toro and Frank Iero, and bassist Mikey Way. Shortly after forming, the band signed to Eyeball Records and released their debut album I Brought You My Bullets, You Brought Me Your Love in 2002. They signed with Reprise Records the next year and released their major label debut Three Cheers for Sweet Revenge in 2004; the album was a commercial success, and was awarded platinum status a little over a year later. The band eclipsed their previous success with their 2006 concept album, The Black Parade, which gained generally favorable reviews among music critics. They have since finished recording their fourth studio album, Danger Days: The True Lives of the Fabulous Killjoys, which was released in November 2010. On March 22, 2013, the band announced their break up. On October 31, 2019, the band announced a reunion, with an opening show in Los Angeles. ",
@@ -1085,66 +1137,7 @@
     },
     {
         "release": {
-            "titulo": "Journey - Frontiers",
-            "url_imagen": "https://i.discogs.com/mlgCG1bQ23Fh5EiZasjs2t7TBHqAgGbkESiquWSDJTA/rs:fit/g:sm/q:90/h:595/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0NTU0/MjEtMTQ1MDYzMTc0/Mi00ODQ0LmpwZWc.jpeg",
-            "sello": "QC 38504",
-            "formato": "Vinyl",
-            "genero": "Rock",
-            "pais": "US",
-            "publicado": "1983",
-            "estilos": "AOR, Classic Rock, Arena Rock"
-        },
-        "tracklist": [
-            {
-                "nombre": "Separate Ways (Worlds Apart)",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Send Her My Love",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Chain Reaction",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "After The Fall",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "Faithfully",
-                "posicion": "A5"
-            },
-            {
-                "nombre": "Edge Of The Blade",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Troubled Child",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Back Talk",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Frontiers",
-                "posicion": "B4"
-            },
-            {
-                "nombre": "Rubicon",
-                "posicion": "B5"
-            }
-        ],
-        "artist": {
-            "nombre": "Journey",
-            "nombre_real": "unasigned",
-            "perfil": "Journey is an American rock band that formed in San Francisco in 1973, composed of former members of Santana and Frumious Bandersnatch. The band has gone through several phases; its strongest commercial success occurred between 1978 and 1987. ",
-            "url_imagen": "https://i.discogs.com/PHQW1YJ1wg6ka0zo292uaPRsmRU1rOJ4mHVbXeokIWw/rs:fit/g:sm/q:90/h:399/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyODM5/NS0xNjYyMTQ0ODQ4/LTcyOTQuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
+            "id": 1226820,
             "titulo": "Queens Of The Stone Age - Villains",
             "url_imagen": "https://i.discogs.com/CJBZeqN_PDN6MufPoftohqHPBmp2bY_rGL89knOXeMc/rs:fit/g:sm/q:90/h:529/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNzQw/NDQxLTE1MDM2OTMx/MzEtNTY4MC5qcGVn.jpeg",
             "sello": "OLE-1125-2",
@@ -1193,6 +1186,7 @@
             }
         ],
         "artist": {
+            "id": 56168,
             "nombre": "Queens Of The Stone Age",
             "nombre_real": "unasigned",
             "perfil": "Alternative Rock/Stoner band formed in 1997 in Palm Desert, California, United States.",
@@ -1201,6 +1195,7 @@
     },
     {
         "release": {
+            "id": 158333,
             "titulo": "Sublime (2) - Sublime",
             "url_imagen": "https://i.discogs.com/TMKnolk-9biVhos_H_haWhI_NmoMs3OkQfqb__a3bEY/rs:fit/g:sm/q:90/h:590/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY0NDc4/MS0xNTU2OTA4MTE5/LTUyOTEuanBlZw.jpeg",
             "sello": "GASD-11413",
@@ -1281,6 +1276,7 @@
             }
         ],
         "artist": {
+            "id": 98600,
             "nombre": "Sublime (2)",
             "nombre_real": "unasigned",
             "perfil": "American band from Long Beach, California formed in 1988 and stopped in 1996. Known as a ska punk band, Sublime also had influences from hardcore punk, reggae, dancehall, dub, folk, hip hop...\r\n\r\nSublime disbanded after their singer Brad Nowell died of a heroin overdose on 25th May 1996, only two months before their self-titled album was released. In 1997, members would formed [a719179]. In 2009, the surviving members Bud Gaugh and Eric Wilson attempted to reform Sublime with Rome Ramirez as their new singer and guitarist, but due to a lawsuit, the band was forced to change their name to [A=Sublime With Rome].\r\n",
@@ -1289,74 +1285,93 @@
     },
     {
         "release": {
-            "titulo": "Rolling Stones* - Steel Wheels",
-            "url_imagen": "https://i.discogs.com/lDkCMDkORUfPnG7ptznwQPZOq_sE0szmxT5Gb3GP-SQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0NDQz/Mi0xNTIzNjkzMTA0/LTE2NDcuanBlZw.jpeg",
-            "sello": "465752 1",
+            "id": 94761,
+            "titulo": "Blur - Parklife",
+            "url_imagen": "https://i.discogs.com/cLVNiXoeE_KfLpbBP5uecVZlmBWbMpEgilkK6meaULg/rs:fit/g:sm/q:90/h:608/w:599/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY3NDMx/MS0xNDE1NTQ4NjYz/LTg5OTYuanBlZw.jpeg",
+            "sello": "FOODLP 10",
             "formato": "Vinyl",
             "genero": "Rock",
-            "pais": "Europe",
-            "publicado": "1989",
-            "estilos": "Blues Rock, Hard Rock, Ballad, Funk, Rock & Roll"
+            "pais": "UK",
+            "publicado": "1994",
+            "estilos": "Indie Rock, Britpop"
         },
         "tracklist": [
             {
-                "nombre": "Sad Sad Sad",
+                "nombre": "Girls & Boys",
                 "posicion": "A1"
             },
             {
-                "nombre": "Mixed Emotions",
+                "nombre": "Tracy Jacks",
                 "posicion": "A2"
             },
             {
-                "nombre": "Terrifying",
+                "nombre": "End Of A Century",
                 "posicion": "A3"
             },
             {
-                "nombre": "Hold On To Your Hat",
+                "nombre": "Parklife",
                 "posicion": "A4"
             },
             {
-                "nombre": "Hearts For Sale",
+                "nombre": "Bank Holiday",
                 "posicion": "A5"
             },
             {
-                "nombre": "Blinded By Love",
+                "nombre": "Badhead",
                 "posicion": "A6"
             },
             {
-                "nombre": "Rock And A Hard Place",
+                "nombre": "The Debt Collector",
+                "posicion": "A7"
+            },
+            {
+                "nombre": "Far Out",
+                "posicion": "A8"
+            },
+            {
+                "nombre": "To The End",
                 "posicion": "B1"
             },
             {
-                "nombre": "Can't Be Seen",
+                "nombre": "London Loves",
                 "posicion": "B2"
             },
             {
-                "nombre": "Almost Hear You Sigh",
+                "nombre": "Trouble In The Message Centre",
                 "posicion": "B3"
             },
             {
-                "nombre": "Continental Drift",
+                "nombre": "Clover Over Dover",
                 "posicion": "B4"
             },
             {
-                "nombre": "Break The Spell",
+                "nombre": "Magic America",
                 "posicion": "B5"
             },
             {
-                "nombre": "Slipping Away",
+                "nombre": "Jubilee",
                 "posicion": "B6"
+            },
+            {
+                "nombre": "This Is A Low",
+                "posicion": "B7"
+            },
+            {
+                "nombre": "Lot 105",
+                "posicion": "B8"
             }
         ],
         "artist": {
-            "nombre": "The Rolling Stones",
+            "id": 7551,
+            "nombre": "Blur",
             "nombre_real": "unasigned",
-            "perfil": "English rock band formed in London in May 1962. They are one of the longest-lived and most commercially successful groups in rock history. Inducted into the Rock And Roll Hall of Fame in 1989 (Performer).\r\n\r\n[i]Band members[/i]\r\n\r\n[u]05/1962 - 05/1963[/u]\r\n[a255182] (Keyboards, piano)\r\n\r\n[u]05/1962 - 06/1969[/u]\r\n[a409290] (Lead and rhythm guitars)\r\n\r\n[u]06/1962 - 10/1962[/u]\r\n[a414255] (Bass)\r\n\r\n[u]06/1962 - 12/1962[/u]\r\n[a677434] (Drums)\r\n\r\n[u]06/1962 - present[/u]\r\n[a90541] (Lead vocals, harmonica, percussion)\r\n[a166570] (Lead and rhythm guitars, acoustic guitar, backing vocals)\r\n\r\n[u]12/1962 - 01/1993[/u]\r\n[a272814] (Bass)\r\n\r\n[u]01/1963 - 08/2021[/u]\r\n[a299325] (Drums and percussion)\r\n\r\n[u]07/1969 - 12/1974[/u]\r\n[a300117] (Lead and slide guitars)\r\n\r\n[u]03/1975 - present[/u]\r\n[a271311] (Guitars, backing vocals)",
-            "url_imagen": "https://i.discogs.com/H3bmFFLnkb4qDTzFQtLRbvMjBNs8bR8R7Zz0JJcMP14/rs:fit/g:sm/q:90/h:690/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwOTkx/LTE2NTY5NjI2MTUt/OTA3Ny5qcGVn.jpeg"
+            "perfil": "Indie rock/pop band with art school roots from London, England.\r\n\r\nBlur formed in 1989 as [a=Seymour] in Colchester, composed of [a=Damon Albarn], [a=Graham Coxon] (1989-2002, 2008- ), [a=Alex James (2)], and [a=Dave Rowntree].\r\nBlur's early releases (the singles \"There's No Other Way\", \"Bang\", \"She's So High\", \"I Know\", and the album \"Leisure\") were considered indie or alternative rock, heavily influenced by the danceable rhythms of \"baggy\" bands like The Stone Roses and noisepop bands like [a=My Bloody Valentine], with strains of weirder ideas running throughout, like Syd Barrett (this was often more readily apparent on several single B-sides, where the group let loose its more atavistic, dark side). By 1992, the group was keen on reinventing themselves with a newer, smarter sound and sense of purpose, eschewing the sounds that were coming out of the U.S. specifically, and returning to a retro spectrum of British rock and pop music: British Invasion groups, Mod groups, Psychedelic Rock, even nostalgic music from World War II. They released their second album, \"Modern Life Is Rubbish\", in 1993, to moderate success and began attracting attention for their stubborn determination to lead Britain out of the miasma that was the grunge years.\r\n\r\nBuilding on the qualified success of \"Modern Life Is Rubbish\" and its accompanying singles, and aided by groups like [a=Suede], Blur rolled out the carpet for the Britpop cultural movement that would all but engulf the UK for two years, releasing in 1994 what was essentially seen by the general public as the Britpop flagship album, \"Parklife\". Everything changed culturally, and Blur was riding the crest of that cultural wave. Following rapidly on the heels of the tipping point that was \"Parklife\", the group's 1995 album \"The Great Escape\" was a vividly nervy and somewhat cartoonish version of the same formula. It left the group with a hangover that it determined it could only cure by taking several steps back from the Britpop sound and culture. The group re-embraced America, digging into influences like Pavement, Dinosaur Jr., The Pixies.\r\n\r\nBy the time Blur's fifth studio album, \"Blur\", came out in 1997, the group had all but severed ties from Britpop and were returning to the same noisy, art rock experimentalism that was a hallmark of their pre-Blur early days in the late 1980s as a indie artrock group [a=Seymour], only this time the music informed by a broader range of influences. Subsequent albums \"13\" and \"Think Tank\" further increased the group's distance from Britpop, eventually encompassing a great diversity of sounds and influences from all over the globe. On February 19, 2015, Blur made a surprise announcement that they'd finished a new album, \"The Magic Whip\", to be made available to the public on April 25, 2015, and also released a new song, \"Go Out\".\r\n\r\nNoteworthy live & session members:\r\n[a=Wayne Hernandez]: lead vocalist with backing choirs since 1997\r\n[a=Simon Tong]: guitarist; replaced Coxon for 2003–04 tour\r\n\r\nWhen marked as a copyright holder, use [l832168].",
+            "url_imagen": "https://i.discogs.com/zaSWN-jXaqklDF3x3tvl1TL2RcS8g9bSGvvDE90LRq0/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTc1NTEt/MTY4OTA2MTkxOS01/NjYzLmpwZWc.jpeg"
         }
     },
     {
         "release": {
+            "id": 58320,
             "titulo": "Roxy Music - Country Life",
             "url_imagen": "https://i.discogs.com/IHJN7kN8disVWJNLjxa8Lkv5n2XwrIFeQ5GYzXlm1vY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY3MjMw/My0xNDc3MTY3NTkz/LTMxODkuanBlZw.jpeg",
             "sello": "ILPS 9303",
@@ -1409,6 +1424,7 @@
             }
         ],
         "artist": {
+            "id": 56621,
             "nombre": "Roxy Music",
             "nombre_real": "unasigned",
             "perfil": "Roxy Music were an English rock band formed in 1970 by [a87721], who became the band's lead vocalist and chief songwriter, and bassist [a439088]. Alongside Ferry, the other longtime members were [a10351] (guitar), [a267770] (saxophone and oboe) and [a261914] (drums and percussion), and other former members include [a634] (synthesizer and \"treatments\"), [a262493] (synthesiser and violin), and [a355635] (bass). Although the band took a break from group activities in 1976 and again in 1983, they reunited for a concert tour in 2001, and toured together intermittently between that time and their break-up in 2011. Ferry frequently enlisted members of Roxy Music as session musicians for his solo releases.\r\n\r\nInducted into the Rock & Roll Hall of Fame in 2019 (Performers) and Roxy Music frontman [a87721] was awarded a CBE by Her Majesty the Queen of England on 30 November 2011.\r\n\r\nDiscogs records that Roxy Music have released 28 albums and 38 compilations since the band’s inception back in 1971. Of these, 18 have made the ‘UK Top 40’ music charts with 11 of them reaching the ‘Top 10’ and 4 albums reaching the No.1 position. The albums to hit the top spot are ‘[m=58357]’ (Dec 1973), ‘[m=41847]’ (May 1980), ‘[m=58313]’ (Jun 1982) and ‘[m58362]’ (Apr 1986). These four albums cumulatively spent 13 weeks at the No.1 position. All 18 charting albums, have in total, been in the chart’s Top 10 for 76 weeks and within the Top 40 for 260 weeks.\r\n\r\nSimilarly, Roxy Music have had success with some of their 49 single/EP releases. In this case, there has been a chart entry for 18 of these releases, with one single making the No.1 spot. In February 1981, Roxy Music hit the singles chart 'top spot' with the John Lennon composed song ‘[m=58331]’ and spent 2 weeks at that coveted position, 9 weeks in the chart’s Top 40 (6 weeks in the Top 10) and 11 weeks overall.\r\n\r\nThe 18 Roxy Music hit singles/EPs have spent time in the UK Top 40 music charts for 128 weeks, with 44 of these within the Top 10. The single with the most time in the UK Charts is ‘[m=58323]’, which entered the charts in April 1979 and overall spent 14 weeks charting.\r\n\r\nRoxy Music’s first album to enter the UK Charts was the self-entitled ‘[m=58135]’ (Island ILPS9200) making its debut on 29/07/1972.  It stayed in the charts for 16 weeks with its highest position being no.10. The album briefly reappeared in February 2018 under the HDCD release (Virgin ROXYCD1) for one week reaching no.47. The first single to chart for Roxy Music was ‘[m=58141]’ (Island WIP6144) on 19/08/1972 and it remained in the UK charts for 12 weeks achieving a high position of no.4 in its fifth week on the charts. (Source: Official Charts Company (UK) (April 2020)).",
@@ -1417,6 +1433,7 @@
     },
     {
         "release": {
+            "id": 74960,
             "titulo": "George Harrison - Cloud Nine",
             "url_imagen": "https://i.discogs.com/OCacWd9XbKY7hCA2b24moUw3Jcd4JWrfa-g58Ik6BHc/rs:fit/g:sm/q:90/h:590/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNTE0/OTgtMTQ0Mzc5ODk4/My04MjM5LmpwZWc.jpeg",
             "sello": "WX 123",
@@ -1473,6 +1490,7 @@
             }
         ],
         "artist": {
+            "id": 243955,
             "nombre": "George Harrison",
             "nombre_real": "unasigned",
             "perfil": "British rock guitarist, singer-songwriter and film producer (born February 25 1943 in Liverpool, England, UK - died November 29, 2001 in Los Angeles, California, USA). Best known as lead guitarist of [a82730].\r\nBy the mid-1960s, he had become an admirer of Indian culture and mysticism, introducing it to the other Beatles. In 1968, he travelled with the other Beatles to Rishikesh, in northern India, to study meditation with [a=Maharishi Mahesh Yogi]. He embraced the Hare Krishna tradition, particularly japa-yoga chanting with beads, and became a lifelong devotee.\r\nInducted into Rock And Roll Hall of Fame in 2004 (Performer).\r\nIn June 1965, he and the other Beatles were appointed Members of the Order of the British Empire (MBE). They received their insignia from the Queen at an investiture at Buckingham Palace on 26 October. In 1988, he was inducted into the Rock and Roll Hall of Fame as a member of The Beatles. He was honoured posthumously with the 2.382nd star on the Hollywood Walk of Fame on 14 April 2009.\r\nMarried to [a1401442] from 21 January 1966 to 1977. Married to [a907704] from 2 September 1978 to his death. Father of [a726756] (with Olivia Harrison). Youngest brother of [a2450148].",
@@ -1481,6 +1499,143 @@
     },
     {
         "release": {
+            "id": 46533,
+            "titulo": "Deftones - Around The Fur",
+            "url_imagen": "https://i.discogs.com/Q--XaOKRjL3jRDVYNAfRCh_VQjiDc-NAaNm2cEmQl7A/rs:fit/g:sm/q:90/h:586/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM3OTAy/NS0xMzg0OTY0ODU2/LTM3NzIuanBlZw.jpeg",
+            "sello": "9 46810-2",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "US",
+            "publicado": "1997",
+            "estilos": "Nu Metal, Alternative Metal, Post-Hardcore"
+        },
+        "tracklist": [
+            {
+                "nombre": "My Own Summer (Shove It)",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Lhabia",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Mascara",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Around The Fur",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Rickets",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Be Quiet And Drive (Far Away)",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Lotion",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Dai The Flu",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Headup",
+                "posicion": "9"
+            },
+            {
+                "nombre": "MX",
+                "posicion": "10.1"
+            },
+            {
+                "nombre": "Bong Hit",
+                "posicion": "10.2"
+            },
+            {
+                "nombre": "Damone",
+                "posicion": "10.3"
+            }
+        ],
+        "artist": {
+            "id": 12210,
+            "nombre": "Deftones",
+            "nombre_real": "unasigned",
+            "perfil": "Deftones is an American alternative metal band from Sacramento, California, formed in 1988. They have released nine albums to date, with three Platinum (Adrenaline, Around the Fur, White Pony) and one Gold certifications (Deftones). The band consists of [a=Chino Moreno] (lead vocals and guitar), [a=Stephen Carpenter] (guitar), [a=Frank Delgado] (keyboards and turntables), and [a=Abe Cunningham] (drums and percussion). \r\n\r\nSince 2009, [a=Sergio Vega] has been standing in on bass while founding bassist [a=Chi Cheng] remained in a \"partially conscious state\" following a car accident. Chi passed away on April 13, 2013. On March 8, 2022, Sergio announced his departure from the band. ",
+            "url_imagen": "https://i.discogs.com/UEqhhF1yHpuo91rl7KiXmZuet_ZRSf2z4x7cOud4yBU/rs:fit/g:sm/q:90/h:315/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEyMjEw/LTE2NDY4MzQ4MTUt/ODE2OS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 876872,
+            "titulo": "Iron Maiden - The Book Of Souls",
+            "url_imagen": "https://i.discogs.com/6IN65JeULbH34NShNcRkyGuwLG4MAiYlT2mR037eJqA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTczOTc3/NTAtMTQ0MDYyMjk2/OC03MjU4LmpwZWc.jpeg",
+            "sello": "0825646089246",
+            "formato": "CD",
+            "genero": "Rock",
+            "pais": "Europe",
+            "publicado": "2015",
+            "estilos": "Heavy Metal"
+        },
+        "tracklist": [
+            {
+                "nombre": "If Eternity Should Fail",
+                "posicion": "1-1"
+            },
+            {
+                "nombre": "Speed Of Light",
+                "posicion": "1-2"
+            },
+            {
+                "nombre": "The Great Unknown",
+                "posicion": "1-3"
+            },
+            {
+                "nombre": "The Red And The Black",
+                "posicion": "1-4"
+            },
+            {
+                "nombre": "When The River Runs Deep",
+                "posicion": "1-5"
+            },
+            {
+                "nombre": "The Book Of Souls",
+                "posicion": "1-6"
+            },
+            {
+                "nombre": "Death Or Glory",
+                "posicion": "2-1"
+            },
+            {
+                "nombre": "Shadows Of The Valley",
+                "posicion": "2-2"
+            },
+            {
+                "nombre": "Tears Of A Clown",
+                "posicion": "2-3"
+            },
+            {
+                "nombre": "The Man Of Sorrows",
+                "posicion": "2-4"
+            },
+            {
+                "nombre": "Empire Of The Clouds",
+                "posicion": "2-5"
+            }
+        ],
+        "artist": {
+            "id": 251595,
+            "nombre": "Iron Maiden",
+            "nombre_real": "unasigned",
+            "perfil": "English heavy metal band formed in Leyton, East London, in 1975 by bassist and primary songwriter [a=Steve Harris]. \r\n\r\n\r\nBand Members:\r\n\r\n[b]Vocals[/b]\r\n[a=Paul Mario Day] (1975-1976)\r\n[a=Dennis Willcock] (1976-1977)\r\n[a=Paul Di'Anno] (1978-1981)\r\n[a=Bruce Dickinson] (1981-1993 and 1999-present)\r\n[a=Blaze Bayley] (1994-1998)\r\n\r\n[b]Guitar[/b]\r\n[a=Terry Rance] (1975-1976)\r\nDave Sullivan (1975-1976)\r\n[a=Dave Murray (2)] (1976-1977 and 1978-present)\r\n[a=Bob Sawyer (3)] (1977)\r\n[a=Terry Wapram] (1977-1978)\r\n[a=Paul Cairns (2)] (1978-1979)\r\n[a=Paul Todd] (1979)\r\n[a=Tony Parsons (3)] (1979)\r\n[a=Dennis Stratton] (1979-1980)\r\n[a=Adrian Smith (2)] (1980-1990 and 1999-present)\r\n[a=Janick Gers] (1990-present)\r\n\r\n[b]Bass[/b]\r\n[a=Steve Harris] (1975-present)\r\n\r\n[b]Drums[/b]\r\n[a=Ron \"Rebel\" Matthews] (1975-1977)\r\nBarry \"[a=Thunderstick]\" Purkis (1977)\r\n[a=Doug Sampson] (1977-1979)\r\n[a=Clive Burr] (1980-1982)\r\n[a=Nicko McBrain] (1982-present)\r\n\r\n[b]Keyboards[/b] \r\n[a=Tony Hustings-Moore] (1977)\r\n[a=Michael Kenney] (1986-present) (Live performances only, not a full member)",
+            "url_imagen": "https://i.discogs.com/WJdyE5tiGWNcBF794ay1EUsSzzH_c0F-ctDg8hmLFgA/rs:fit/g:sm/q:90/h:587/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1MTU5/NS0xNjM4NTE1NTIz/LTkwNjYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 15906,
             "titulo": "Death (2) - Leprosy",
             "url_imagen": "https://i.discogs.com/TobnHiSjMC4QSmdaEjfx-wQ6YPJ-VEBYJ_UXY84Te9s/rs:fit/g:sm/q:90/h:605/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ2ODIz/My0xNDc0NjY1Nzg4/LTY0NDEuanBlZw.jpeg",
             "sello": "88561-8248-1",
@@ -1525,6 +1680,7 @@
             }
         ],
         "artist": {
+            "id": 254268,
             "nombre": "Death (2)",
             "nombre_real": "unasigned",
             "perfil": "Formed in 1983 as [url=https://www.discogs.com/artist/1787042-Mantas-3]Mantas[/url] with Chuck Schuldiner on vocals and guitar, Rick Rozz on guitar and Barney 'Kam' Lee on drums and vocals. In 1984 the band recorded their first demo called \"Death By Metal\". Soon after the recording the band split up and Chuck formed a new band named Death.\r\n\r\n1984: Rick Rozz (guitar), Kam Lee (drums), Chuck Schuldiner (guitar, vocals).\r\n1985: Rick Rozz leaves the band. Scott Carlson (bass) and Matt Olivio (guitar) from the Michigan based band Genocide joined Death. Kam left the band. A couple of months later both Matt and Scott left. Chuck moved to San Francisco and joined forces with Eric Brecht (drums). At the end of the year Chuck returned to Florida bandless.\r\n1986: Chuck moved to Toronto to join Slaughter. After a couple of weeks Chuck moved back to Florida and then once again to San Francisco to join up with drummer Chris Reifert. During rehearsals Steve DiGiorgio played bass while Death and [a=Sadus] shared a rehearsal space. They recorded \"Scream Bloody Gore\" during the summer.\r\n1987: \"Scream Bloody Gore\" released March 1987. Chuck moved back to Florida and teamed up with Rick Rozz (guitar), Terry Butler (bass) and Bill Andrews (drums).\r\n1988: Rick Rozz replaced by James Murphy.\r\n1990: James Murphy replaced by Albert Gonzales who in the same year was replaced by Paul Masvidal. The band decided to tour Europe without Chuck with Walter Trachsler on guitar and Louie Carrisalez handling the vocals. \r\n1991: Chuck recruits Sean Reinert (drums), Paul Masvidal (guitar) and Steve DiGiorgio (bass). Steve DiGiorgio replaced by Skott Carino.\r\n1993: Paul Masvidal and Sean Reinert leaves replaced by Andy LaRocque (guitar) and Gene Hoglan (drums) and Steve DiGiorgio rejoins. Craig Locicero helps out on their European tour and Ralph Santolla on the US tour and the Easter festivals in Europe. \r\n1995: Bobby Koelble on guitar and Kelly Conlon on bass. \r\n1996: A break so Chuck can think about the band's future. During this period Chuck starts the band [a=Control Denied].\r\n1998: Shannon Hamm on guitar, Scott Clendenin on bass and Richard Christy on drums.\r\n1999: Chuck is diagnosed with a brainstem tumor.\r\n2001: \"Live In L.A.\" and \"Live In Eindhoven\" albums were released by Nuclear Blast to earn some money for Chuck's treatment. Chuck passed away on December 13th that year.\r\n",
@@ -1533,6 +1689,7 @@
     },
     {
         "release": {
+            "id": 37619,
             "titulo": "Bob Seger & The Silver Bullet Band* - Live Bullet",
             "url_imagen": "https://i.discogs.com/1SifcMYzaXwcNLJf5RAEc7PmPx9K8-AT1ydyDx43uJA/rs:fit/g:sm/q:90/h:600/w:597/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNjUw/MDAtMTM4MzcxNTIx/OC03OTYyLmpwZWc.jpeg",
             "sello": "SKBB-11523",
@@ -1601,6 +1758,7 @@
             }
         ],
         "artist": {
+            "id": 268911,
             "nombre": "Bob Seger And The Silver Bullet Band",
             "nombre_real": "unasigned",
             "perfil": "",
@@ -1609,6 +1767,7 @@
     },
     {
         "release": {
+            "id": 13266,
             "titulo": "Bryan Adams - Cuts Like A Knife",
             "url_imagen": "https://i.discogs.com/3TK3zyJ4eIIGsv4RB5qd7lJbG1xFZumM_GU0e4y1LX8/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE1Njc1/MDktMTMxOTYyMzM4/My5qcGVn.jpeg",
             "sello": "SP 4919",
@@ -1661,6 +1820,7 @@
             }
         ],
         "artist": {
+            "id": 10933,
             "nombre": "Bryan Adams",
             "nombre_real": "unasigned",
             "perfil": "Canadian rock singer, guitarist and photographer, born November 5th, 1959, in Ontario. His recording debut was at the age of fifteen, with the glam rock band [a816901].  After a third version of Roxy Roller and one album entitled \"If Wishes Were Horses\", he went solo by releasing one disco single before striking out on a pop career.\r\n\r\n[b]Please note that Bryan Adams the singer-songwriter and Bryan Adams the [i]photographer[/i] are one and the same. This profile should be used for photo credits as well.[/b]",
@@ -1669,94 +1829,7 @@
     },
     {
         "release": {
-            "titulo": "Pink Floyd - Another Brick In The Wall (Part II)",
-            "url_imagen": "https://i.discogs.com/7gdVsro3t9U9jxHgodxKvL23oItFOac60wZJ1syWVYM/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUxMDM1/OC0xMjc1NDA2ODQ5/LmpwZWc.jpeg",
-            "sello": "HAR 5194",
-            "formato": "Vinyl",
-            "genero": "Rock",
-            "pais": "UK",
-            "publicado": "1979",
-            "estilos": "Pop Rock, Prog Rock"
-        },
-        "tracklist": [
-            {
-                "nombre": "Another Brick In The Wall (Part II)",
-                "posicion": "A"
-            },
-            {
-                "nombre": "One Of My Turns",
-                "posicion": "B"
-            }
-        ],
-        "artist": {
-            "nombre": "Pink Floyd",
-            "nombre_real": "unasigned",
-            "perfil": "Pink Floyd was an English rock band from London. Founded in 1965, the group achieved worldwide acclaim, initially with innovative psychedelic music, and later in a genre that came to be termed progressive rock.\r\n\r\nDistinguished by philosophical lyrics, musical experimentation, frequent use of sound effects and elaborate live shows, Pink Floyd remains one of the most commercially successful and influential groups in the history of popular music.\r\n\r\n[a=David Gilmour] – guitar, slide guitar, vocals (1968-2014)\r\n[a=Richard Wright] – keyboards, vocals (1965-1980, 1987-2008)\r\n[a=Nick Mason] – drums, percussion, sound effects (1965-2014)\r\n[a=Roger Waters] – bass guitar, vocals, sound effects (1965-1985)\r\n[a=Syd Barrett] – guitar, vocals (1965-1968)\r\n\r\n[b]Other players:[/b]\r\n[a=Rado Klose] – guitar (1965)\r\n[a=Jon Carin] – backing vocals, keyboards, slide guitar, sound effects (1985-1995)\r\n[a=Guy Pratt] – bass guitar, backing vocals (1987-1995)\r\n\r\nInducted into Rock And Roll Hall of Fame in 1996 (Performer).\r\nGroup name was taken from both [a=Pink Anderson] and [a=Floyd \"Dipper Boy\" Council] as a tribute to the American blues music they loved.",
-            "url_imagen": "https://i.discogs.com/jQidWO3_h7lBerDbfbxxGkp7qnjxo6OTEhT06EWrQ1A/rs:fit/g:sm/q:90/h:670/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ1NDY3/LTE0ODgxMTYxMTEt/Nzc3OC5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Mad Season - Above",
-            "url_imagen": "https://i.discogs.com/8AbBEUdlU1dAYo3-h7uOZTdRs9ZOjOot7LFTEsWFxFM/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM2ODIz/NC0xMzE0OTMxODI0/LmpwZWc.jpeg",
-            "sello": "CK 67057",
-            "formato": "CD",
-            "genero": "Rock",
-            "pais": "US",
-            "publicado": "1995",
-            "estilos": "Alternative Rock, Grunge"
-        },
-        "tracklist": [
-            {
-                "nombre": "Wake Up",
-                "posicion": "1"
-            },
-            {
-                "nombre": "X-Ray Mind",
-                "posicion": "2"
-            },
-            {
-                "nombre": "River Of Deceit",
-                "posicion": "3"
-            },
-            {
-                "nombre": "I'm Above",
-                "posicion": "4"
-            },
-            {
-                "nombre": "Artificial Red",
-                "posicion": "5"
-            },
-            {
-                "nombre": "Lifeless Dead",
-                "posicion": "6"
-            },
-            {
-                "nombre": "I Don't Know Anything",
-                "posicion": "7"
-            },
-            {
-                "nombre": "Long Gone Day",
-                "posicion": "8"
-            },
-            {
-                "nombre": "November Hotel",
-                "posicion": "9"
-            },
-            {
-                "nombre": "All Alone",
-                "posicion": "10"
-            }
-        ],
-        "artist": {
-            "nombre": "Mad Season",
-            "nombre_real": "unasigned",
-            "perfil": "Mad Season were a super-group in the Seattle scene in the 1990s, featuring [a=Layne Staley] of [a=Alice in Chains], [a=Mike McCready] of [a=Pearl Jam], [a=Barrett Martin] of [a=Screaming Trees], and [a=John Baker Saunders] of [url=http://www.discogs.com/artist/99923-Walkabouts-The]The Walkabouts[/url]. The band only existed for one album. \r\n\r\nJohn Baker Saunders passed away in 1999 from a heroin overdose. Layne Staley passed away in 2002.\r\n\r\nLine-up:\r\nLayne Staley - vocals, guitar\r\nMike McCready - guitars\r\nJohn Baker Saunders - bass\r\nBarrett Martin - drums, percussion",
-            "url_imagen": "https://i.discogs.com/Bsbol9UNafAFfIBd8eOKOeQOgZ7zbUMwue7C6lhRONM/rs:fit/g:sm/q:90/h:476/w:480/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY5OTUz/LTEzOTQyMTM0NTYt/MjQyMi5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
+            "id": 3697,
             "titulo": "Opeth - Blackwater Park",
             "url_imagen": "https://i.discogs.com/vO-YtwrhCtZ6eOITSFN2bDgR3N-9otSfIEcr8wCw2Zs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwMDA4/My0xMzI1MjQwNjM0/LmpwZWc.jpeg",
             "sello": "CDMFN 264",
@@ -1801,6 +1874,7 @@
             }
         ],
         "artist": {
+            "id": 245797,
             "nombre": "Opeth",
             "nombre_real": "unasigned",
             "perfil": "Swedish progressive metal band from Stockholm, formed in 1990. Though the group has been through several personnel changes, singer, guitarist, and songwriter [a=Mikael Åkerfeldt] has remained Opeth's driving force throughout the years. Opeth has consistently incorporated progressive, folk, blues, classical and jazz influences into their usually lengthy compositions, as well as strong influences from black metal and death metal, especially in their early works. Many songs include acoustic guitar passages and strong dynamic shifts, as well as both death growls and clean vocals. Opeth rarely made live appearances supporting their first four albums; but since conducting their first world tour after the 2001 release of [i]Blackwater Park[/i], they have led several world tours.\r\n\r\nIn 2011, they published [i]Heritage[/i]. It represents a drastic change in style from their previous albums, adopting a mostly progressive rock sound and only clean singing. Åkerfeldt commented on the diversity of Opeth's music: \"I don't see the point of playing in a band and going just one way when you can do everything. It would be impossible for us to play just death metal; that is our roots, but we are now a mishmash of everything, and not purists to any form of music. It's impossible for us to do that, and quite frankly I would think of it as boring to be in a band that plays just metal music. We're not afraid to experiment, or to be caught with our pants down, so to speak. That's what keeps us going.\" (Metal Hammer)\r\n\r\nOn August 26, 2014, Opeth released its eleventh studio album, titled [i]Pale Communion[/i]. Fredrik Åkesson, spoke about the new direction the band was taking: \"It would be interesting to do a really heavy album, but in a different way. Not to go back, we're not about that. I'm still very proud with the last two albums, I think it's interesting to listen to them, even if I listen in an objective way.\" (Ultimate Guitar)\r\n\r\nIn 2016, Opeth founded their own label, [l1067696] and published the twelfth studio album \"Sorceress.\"",
@@ -1809,6 +1883,7 @@
     },
     {
         "release": {
+            "id": 9719,
             "titulo": "Minor Threat - Minor Threat",
             "url_imagen": "https://i.discogs.com/S5HQdmAuR-rjwZgD89pIpJUxCxi-xCcmrSyBRot9Ato/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1ODg0/MDctMTM0MTM2OTg0/MC0yNzcxLmpwZWc.jpeg",
             "sello": "DISCHORD № 12",
@@ -1869,6 +1944,7 @@
             }
         ],
         "artist": {
+            "id": 252202,
             "nombre": "Minor Threat",
             "nombre_real": "unasigned",
             "perfil": "Influential American hardcore punk band from Washington, D.C. formed in 1980 and disbanded in 1983. \r\nTheir song \"Straight Edge\" gave birth to the straight edge movement, which emphasized a lifestyle without alcohol and drugs.",
@@ -1877,158 +1953,97 @@
     },
     {
         "release": {
-            "titulo": "The Flaming Lips - The Soft Bulletin",
-            "url_imagen": "https://i.discogs.com/Rmh-8oU0wJ8HI9fN7_ZhDXyiIr371o2Yfi7IE4l9l_E/rs:fit/g:sm/q:90/h:588/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNzIy/NjYtMTIzNTMzMTY0/My5qcGVn.jpeg",
-            "sello": "9 46876-2",
-            "formato": "CD",
-            "genero": "Rock",
-            "pais": "US",
-            "publicado": "1999",
-            "estilos": "Psychedelic Rock, Experimental, Indie Rock, Noise Rock"
-        },
-        "tracklist": [
-            {
-                "nombre": "Race For The Prize (Remix)",
-                "posicion": "1"
-            },
-            {
-                "nombre": "A Spoonful Weighs A Ton",
-                "posicion": "2"
-            },
-            {
-                "nombre": "The Spark That Bled",
-                "posicion": "3"
-            },
-            {
-                "nombre": "The Spiderbite Song",
-                "posicion": "4"
-            },
-            {
-                "nombre": "Buggin' (Remix)",
-                "posicion": "5"
-            },
-            {
-                "nombre": "What Is The Light?",
-                "posicion": "6"
-            },
-            {
-                "nombre": "The Observer",
-                "posicion": "7"
-            },
-            {
-                "nombre": "Waitin' For A Superman",
-                "posicion": "8"
-            },
-            {
-                "nombre": "Suddenly Everything Has Changed",
-                "posicion": "9"
-            },
-            {
-                "nombre": "The Gash",
-                "posicion": "10"
-            },
-            {
-                "nombre": "Feeling Yourself Disintegrate",
-                "posicion": "11"
-            },
-            {
-                "nombre": "Sleeping On The Roof",
-                "posicion": "12"
-            },
-            {
-                "nombre": "Race For The Prize",
-                "posicion": "13"
-            },
-            {
-                "nombre": "Waitin' For A Superman (Remix)",
-                "posicion": "14"
-            }
-        ],
-        "artist": {
-            "nombre": "The Flaming Lips",
-            "nombre_real": "unasigned",
-            "perfil": "The Flaming Lips are an American psychedelic rock band formed in 1983 in Oklahoma City, OK, USA.\r\nThe band currently consists of Wayne Coyne (vocals, guitar, keyboards), Steven Drozd (guitars, keyboards, bass, vocals), Derek Brown (keyboards, guitars, percussion), Matt Duckworth Kirksey (drums, percussion, keyboards) and Nicholas Ley (percussion, drums).",
-            "url_imagen": "https://i.discogs.com/_WuWw4dubAKivI_FVohYJ-k4FhvKfCBnjSvqecUeaow/rs:fit/g:sm/q:90/h:364/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY3MTU2/LTEzMTU5NTYyODAu/anBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Blur - Blur",
-            "url_imagen": "https://i.discogs.com/cpvJYUr-m7ZHpHwIBe_U_KL-76BE9HQr6qp5MY9ky4k/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwNjMy/MS0xMTM5ODYzMDA4/LmpwZWc.jpeg",
-            "sello": "FOOD LP 19",
+            "id": 18466,
+            "titulo": "Grateful Dead* - Europe '72",
+            "url_imagen": "https://i.discogs.com/SEHphfe4Q4HBgOdbWgPiaIsqT7ksQmQV8ljARE6-fVg/rs:fit/g:sm/q:90/h:465/w:471/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEyOTc1/NzAtMTUyNDA0NzQ3/MS05NzIzLmpwZWc.jpeg",
+            "sello": "3WX 2668",
             "formato": "Vinyl",
             "genero": "Rock",
-            "pais": "UK",
-            "publicado": "1997",
-            "estilos": "Alternative Rock, Britpop"
+            "pais": "US",
+            "publicado": "1972",
+            "estilos": "Folk Rock, Psychedelic Rock"
         },
         "tracklist": [
             {
-                "nombre": "Beetlebum",
+                "nombre": "Cumberland Blues",
                 "posicion": "A1"
             },
             {
-                "nombre": "Song 2",
+                "nombre": "He's Gone",
                 "posicion": "A2"
             },
             {
-                "nombre": "Country Sad Ballad Man",
+                "nombre": "One More Saturday Night",
                 "posicion": "A3"
             },
             {
-                "nombre": "M.O.R.",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "On Your Own",
-                "posicion": "A5"
-            },
-            {
-                "nombre": "Theme From Retro",
-                "posicion": "A6"
-            },
-            {
-                "nombre": "You're So Great",
-                "posicion": "A7"
-            },
-            {
-                "nombre": "Death Of A Party",
+                "nombre": "Jack Straw",
                 "posicion": "B1"
             },
             {
-                "nombre": "Chinese Bombs",
+                "nombre": "You Win Again",
                 "posicion": "B2"
             },
             {
-                "nombre": "I'm Just A Killer For Your Love",
+                "nombre": "China Cat Sunflower",
                 "posicion": "B3"
             },
             {
-                "nombre": "Look Inside America",
+                "nombre": "I Know You Rider",
                 "posicion": "B4"
             },
             {
-                "nombre": "Strange News From Another Star",
-                "posicion": "B5"
+                "nombre": "Brown-Eyed Woman",
+                "posicion": "C1"
             },
             {
-                "nombre": "Movin' On",
-                "posicion": "B6"
+                "nombre": "Hurts Me Too",
+                "posicion": "C2"
             },
             {
-                "nombre": "Essex Dogs",
-                "posicion": "B7"
+                "nombre": "Ramble On Rose",
+                "posicion": "C3"
+            },
+            {
+                "nombre": "Sugar Magnolia",
+                "posicion": "D1"
+            },
+            {
+                "nombre": "Mr. Charlie",
+                "posicion": "D2"
+            },
+            {
+                "nombre": "Tennessee Jed",
+                "posicion": "D3"
+            },
+            {
+                "nombre": "Truckin'",
+                "posicion": "E1"
+            },
+            {
+                "nombre": "Epilog",
+                "posicion": "E2"
+            },
+            {
+                "nombre": "Prelude",
+                "posicion": "F1"
+            },
+            {
+                "nombre": "Morning Dew",
+                "posicion": "F2"
             }
         ],
         "artist": {
-            "nombre": "Blur",
+            "id": 246650,
+            "nombre": "The Grateful Dead",
             "nombre_real": "unasigned",
-            "perfil": "Indie rock/pop band with art school roots from London, England.\r\n\r\nBlur formed in 1989 as [a=Seymour] in Colchester, composed of [a=Damon Albarn], [a=Graham Coxon] (1989-2002, 2008- ), [a=Alex James (2)], and [a=Dave Rowntree].\r\nBlur's early releases (the singles \"There's No Other Way\", \"Bang\", \"She's So High\", \"I Know\", and the album \"Leisure\") were considered indie or alternative rock, heavily influenced by the danceable rhythms of \"baggy\" bands like The Stone Roses and noisepop bands like [a=My Bloody Valentine], with strains of weirder ideas running throughout, like Syd Barrett (this was often more readily apparent on several single B-sides, where the group let loose its more atavistic, dark side). By 1992, the group was keen on reinventing themselves with a newer, smarter sound and sense of purpose, eschewing the sounds that were coming out of the U.S. specifically, and returning to a retro spectrum of British rock and pop music: British Invasion groups, Mod groups, Psychedelic Rock, even nostalgic music from World War II. They released their second album, \"Modern Life Is Rubbish\", in 1993, to moderate success and began attracting attention for their stubborn determination to lead Britain out of the miasma that was the grunge years.\r\n\r\nBuilding on the qualified success of \"Modern Life Is Rubbish\" and its accompanying singles, and aided by groups like [a=Suede], Blur rolled out the carpet for the Britpop cultural movement that would all but engulf the UK for two years, releasing in 1994 what was essentially seen by the general public as the Britpop flagship album, \"Parklife\". Everything changed culturally, and Blur was riding the crest of that cultural wave. Following rapidly on the heels of the tipping point that was \"Parklife\", the group's 1995 album \"The Great Escape\" was a vividly nervy and somewhat cartoonish version of the same formula. It left the group with a hangover that it determined it could only cure by taking several steps back from the Britpop sound and culture. The group re-embraced America, digging into influences like Pavement, Dinosaur Jr., The Pixies.\r\n\r\nBy the time Blur's fifth studio album, \"Blur\", came out in 1997, the group had all but severed ties from Britpop and were returning to the same noisy, art rock experimentalism that was a hallmark of their pre-Blur early days in the late 1980s as a indie artrock group [a=Seymour], only this time the music informed by a broader range of influences. Subsequent albums \"13\" and \"Think Tank\" further increased the group's distance from Britpop, eventually encompassing a great diversity of sounds and influences from all over the globe. On February 19, 2015, Blur made a surprise announcement that they'd finished a new album, \"The Magic Whip\", to be made available to the public on April 25, 2015, and also released a new song, \"Go Out\".\r\n\r\nNoteworthy live & session members:\r\n[a=Wayne Hernandez]: lead vocalist with backing choirs since 1997\r\n[a=Simon Tong]: guitarist; replaced Coxon for 2003–04 tour\r\n\r\nWhen marked as a copyright holder, use [l832168].",
-            "url_imagen": "https://i.discogs.com/zaSWN-jXaqklDF3x3tvl1TL2RcS8g9bSGvvDE90LRq0/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTc1NTEt/MTY4OTA2MTkxOS01/NjYzLmpwZWc.jpeg"
+            "perfil": "Grateful Dead was an American rock band (1965–1995) formed in the San Francisco Bay Area. Initially formed in 1964 as [a1602134].",
+            "url_imagen": "https://i.discogs.com/bAbVGWBQpA6z3yZA7bTLIGpOMYFug0N8XCkeSOp7oH0/rs:fit/g:sm/q:90/h:600/w:590/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI0NjY1/MC0xMTQzOTAzNTEw/LmpwZWc.jpeg"
         }
     },
     {
         "release": {
+            "id": 168639,
             "titulo": "Fugazi - Fugazi",
             "url_imagen": "https://i.discogs.com/4R2Cq9MKwuHqnVAWTano50St_QT_7K7gangQnNM0pO0/rs:fit/g:sm/q:90/h:603/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMzMTkx/OTAtMTQ0NTE2Mjc5/MC05OTg0LmpwZWc.jpeg",
             "sello": "DISCHORD 30",
@@ -2069,6 +2084,7 @@
             }
         ],
         "artist": {
+            "id": 82103,
             "nombre": "Fugazi",
             "nombre_real": "unasigned",
             "perfil": "American punk rock band that formed in Washington, D.C. in 1987. The band consists of guitarists and vocalists Ian MacKaye and Guy Picciotto, bassist Joe Lally and drummer Brendan Canty. They are noted for their DIY ethic, manner of business practice, and contempt towards the music industry. The band has been on an indefinite break since 2003.",
@@ -2077,6 +2093,7 @@
     },
     {
         "release": {
+            "id": 267863,
             "titulo": "Iron Maiden - The Final Frontier",
             "url_imagen": "https://i.discogs.com/rLmW_wvqK4zHU-CvOHDwk0LJekKy8RJ6pXbI9RTfT04/rs:fit/g:sm/q:90/h:606/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1OTMy/MDItMTQ0MjM1NTY3/OC05NzkyLmpwZWc.jpeg",
             "sello": "50999 6477722 1",
@@ -2129,6 +2146,7 @@
             }
         ],
         "artist": {
+            "id": 251595,
             "nombre": "Iron Maiden",
             "nombre_real": "unasigned",
             "perfil": "English heavy metal band formed in Leyton, East London, in 1975 by bassist and primary songwriter [a=Steve Harris]. \r\n\r\n\r\nBand Members:\r\n\r\n[b]Vocals[/b]\r\n[a=Paul Mario Day] (1975-1976)\r\n[a=Dennis Willcock] (1976-1977)\r\n[a=Paul Di'Anno] (1978-1981)\r\n[a=Bruce Dickinson] (1981-1993 and 1999-present)\r\n[a=Blaze Bayley] (1994-1998)\r\n\r\n[b]Guitar[/b]\r\n[a=Terry Rance] (1975-1976)\r\nDave Sullivan (1975-1976)\r\n[a=Dave Murray (2)] (1976-1977 and 1978-present)\r\n[a=Bob Sawyer (3)] (1977)\r\n[a=Terry Wapram] (1977-1978)\r\n[a=Paul Cairns (2)] (1978-1979)\r\n[a=Paul Todd] (1979)\r\n[a=Tony Parsons (3)] (1979)\r\n[a=Dennis Stratton] (1979-1980)\r\n[a=Adrian Smith (2)] (1980-1990 and 1999-present)\r\n[a=Janick Gers] (1990-present)\r\n\r\n[b]Bass[/b]\r\n[a=Steve Harris] (1975-present)\r\n\r\n[b]Drums[/b]\r\n[a=Ron \"Rebel\" Matthews] (1975-1977)\r\nBarry \"[a=Thunderstick]\" Purkis (1977)\r\n[a=Doug Sampson] (1977-1979)\r\n[a=Clive Burr] (1980-1982)\r\n[a=Nicko McBrain] (1982-present)\r\n\r\n[b]Keyboards[/b] \r\n[a=Tony Hustings-Moore] (1977)\r\n[a=Michael Kenney] (1986-present) (Live performances only, not a full member)",
@@ -2137,320 +2155,115 @@
     },
     {
         "release": {
-            "titulo": "The Oscar Peterson Trio - Night Train",
-            "url_imagen": "https://i.discogs.com/UxY3OmRD9HoUSiGWCThIDxmeMuuYqTyFevKRpJBFZ9s/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwMzM4/OTgwLTE1OTMzNTQ0/ODMtNDM4NS5qcGVn.jpeg",
-            "sello": "V-8538",
-            "formato": "Vinyl",
-            "genero": "Jazz",
+            "id": 1234880,
+            "titulo": "Foo Fighters - Concrete And Gold",
+            "url_imagen": "https://i.discogs.com/PjCa3nfxLqJYqUhC3AItbgssBZAf0SEJfm4jT04O5BE/rs:fit/g:sm/q:90/h:532/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwODIy/ODUwLTE1MDgzMTAx/NDQtNjAwNC5qcGVn.jpeg",
+            "sello": "88985-45601-2",
+            "formato": "CD",
+            "genero": "Rock",
             "pais": "US",
-            "publicado": "1963"
+            "publicado": "2017",
+            "estilos": "Alternative Rock"
         },
         "tracklist": [
             {
-                "nombre": "Night Train",
+                "nombre": "T-Shirt",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Run",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Make It Right",
+                "posicion": "3"
+            },
+            {
+                "nombre": "The Sky Is A Neighborhood",
+                "posicion": "4"
+            },
+            {
+                "nombre": "La Dee Da",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Dirty Water",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Arrows",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Happy Ever After (Zero Hour)",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Sunday Rain",
+                "posicion": "9"
+            },
+            {
+                "nombre": "The Line",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Concrete And Gold",
+                "posicion": "11"
+            }
+        ],
+        "artist": {
+            "id": 198282,
+            "nombre": "Foo Fighters",
+            "nombre_real": "unasigned",
+            "perfil": "Alternative Rock band from Seattle, Washington, USA. Formed 1994, originally a one-man-band created by [a=Dave Grohl] in 1994-1995.\r\n\r\n[b][u]Current Members:[/u][/b]\r\nDave Grohl - Vocals/Rhythm guitar (1994-)\r\nNate Mendel - Bass (1995-)\r\nPat Smear - Rhythm guitar (1995-1997 2006-)\r\nChris Shifflett - Lead guitar/Backing vocals (1999-)\r\nRami Jaffee - Keyboards (2017-)\r\nJosh Freese - Drums (2023-)\r\n\r\n[b]Former Members:[/b]\r\nWilliam Goldsmith - Drums (1995-1997)\r\nFranz Stahl - Lead guitar/Backing vocals (1997-1999)\r\nTaylor Hawkins (died 2022) - Drums/Backing vocals (1997-2022)",
+            "url_imagen": "https://i.discogs.com/WPr53RUYGoZJ9OnhwJV-yiO8g2x9HSdn9Jp2LeL5swU/rs:fit/g:sm/q:90/h:227/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE5ODI4/Mi0xNjQ5MTAyNzE3/LTc0MzIuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 54824,
+            "titulo": "Pat Metheny Group - American Garage",
+            "url_imagen": "https://i.discogs.com/gahUmkp8q5nTzOSDmSVQJUZRpKO3ShfmooUefVuaiw4/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExMzgy/MDYtMTY2MTc2MjU2/My05NzU3LmpwZWc.jpeg",
+            "sello": "ECM 1155",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "Germany",
+            "publicado": "1979",
+            "estilos": "Fusion, Contemporary Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "(Cross The) Heartland",
                 "posicion": "A1"
             },
             {
-                "nombre": "C Jam Blues",
+                "nombre": "Airstream",
                 "posicion": "A2"
             },
             {
-                "nombre": "Georgia On My Mind",
+                "nombre": "The Search",
                 "posicion": "A3"
             },
             {
-                "nombre": "Bags' Groove",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "Moten Swing",
-                "posicion": "A5"
-            },
-            {
-                "nombre": "Easy Does It",
-                "posicion": "A6"
-            },
-            {
-                "nombre": "Honey Dripper",
+                "nombre": "American Garage",
                 "posicion": "B1"
             },
             {
-                "nombre": "Things Ain't What They Used To Be",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "I Got It Bad And That Ain't Good",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Band Call",
-                "posicion": "B4"
-            },
-            {
-                "nombre": "Hymn To Freedom",
-                "posicion": "B5"
-            }
-        ],
-        "artist": {
-            "nombre": "The Oscar Peterson Trio",
-            "nombre_real": "unasigned",
-            "perfil": "",
-            "url_imagen": "https://i.discogs.com/t8iVrhv1yjvimfo-49xNIoEoBBYkfgi27-IfxY2KjgE/rs:fit/g:sm/q:90/h:340/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1NTY0/Ni0xMzM2OTg1MDYz/LTcxNTYucG5n.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Chuck Mangione - Feels So Good",
-            "url_imagen": "https://i.discogs.com/-HxlDz9dz-sZJWOrtuysW9CVbIkBY2Etus9-C1YTqNo/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0ODIw/My0xNTkwNDQ4NzQx/LTYwNjYuanBlZw.jpeg",
-            "sello": "SP-4658",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1977",
-            "estilos": "Contemporary Jazz, Soul-Jazz"
-        },
-        "tracklist": [
-            {
-                "nombre": "Feels So Good",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Maui-Waui",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Theme From \"Side Street\"",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Hide & Seek (Ready Or Not Here I Come)",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Last Dance",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "The XIth Commandment",
-                "posicion": "B3"
-            }
-        ],
-        "artist": {
-            "nombre": "Chuck Mangione",
-            "nombre_real": "unasigned",
-            "perfil": "American flugelhorn player and composer.\r\n\r\nBorn: 29 November 1940 in Rochester, New York, USA.\r\n\r\nBrother of pianist [a=Gap Mangione].",
-            "url_imagen": "https://i.discogs.com/eIlt1CA2K9xPfQA3filVbkACjLQY6XmLRDqBNVnPJWQ/rs:fit/g:sm/q:90/h:316/w:453/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTkyMDUx/LTE0NjU5NDc3ODgt/Njk1Mi5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Miles Davis - Jack Johnson (Original Soundtrack Recording)",
-            "url_imagen": "https://i.discogs.com/qU180KbUGM4r8Qt8S39O2UvrmM8u9O2PoLPs1-l92pY/rs:fit/g:sm/q:90/h:614/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwNDcz/MTgtMTQwOTcwMzMy/Ni04Njk2LmpwZWc.jpeg",
-            "sello": "S 30455",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1971",
-            "estilos": "Jazz-Rock, Fusion"
-        },
-        "tracklist": [
-            {
-                "nombre": "Right Off",
-                "posicion": "A"
-            },
-            {
-                "nombre": "Yesternow",
-                "posicion": "B"
-            }
-        ],
-        "artist": {
-            "nombre": "Miles Davis",
-            "nombre_real": "unasigned",
-            "perfil": "Trumpeter, bandleader, composer, and one of the most important figures in jazz music history, and music history in general. Davis adopted a variety of musical directions in a five-decade career that kept him at the forefront of many major stylistic developments in jazz. Winner of eight Grammy awards.\r\n\r\nBorn: 26 May 1926 in Alton, Illinois, USA.\r\nDied: 28 September 1991 in Santa Monica, California, USA (aged 65).\r\n\r\nBest known for his seminal modern jazz album \"[m=5460]\" (1959), the highest selling jazz album of all time with six million copies sold.\r\n\r\nMiles went to NYC to study at the academic school for musicians, where he met [a=Charlie Parker]. They started playing together from 1945. In 1948 Miles Davis started to make his own ensembles, at that time he met [a=Gil Evans], The Miles Davis Nonet was born. From the few recordings they made in 1949 to 1950 came the album \"[m=62308]\" (1957), with Davis and Evans going on to work more together in the future.\r\n\r\nMiles Davis was one of the musicians who introduced the 'Hard Bop' in the mid 1950s. In the late 1960s he started to experiment with electronic instruments and rock and funk rhythms. In the mid 1970s he stopped playing because of health problems, though in 1980 he made an 'electronical' comeback.\r\n\r\nInducted into Rock And Roll Hall of Fame in 2006 (Performer). Winner of Eight Grammy Awards.\r\n\r\nHe married dancer/actress [a=Frances Taylor Davis] on December 12, 1959; they divorced in 1968. He then married singer [a=Betty Mabry] in September 1968; they divorced in 1970. He then married actress [a=Cicely Tyson] on November 26, 1981; they divorced in 1989. Father of [a=Cheryl Davis] & [a=Erin Davis]. Uncle of [a=Vince Wilburn, Jr.]",
-            "url_imagen": "https://i.discogs.com/fvfSeynJ9rM5-55MQKikNuvvxxFpzVEcLZCls3-qRE0/rs:fit/g:sm/q:90/h:304/w:304/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIzNzU1/LTEzOTQzODczNDMt/NDUwMC5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Bill Evans Trio* - Portrait In Jazz",
-            "url_imagen": "https://i.discogs.com/K3CbBVsR28dXD9CY_Cqdnuu39W9Qkb_GhUlK5ZiBd8Y/rs:fit/g:sm/q:90/h:603/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM1OTUz/MTEtMTY2ODAyNjU2/NS02MTE2LmpwZWc.jpeg",
-            "sello": "RLP 12-315",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1960",
-            "estilos": "Post Bop, Modal"
-        },
-        "tracklist": [
-            {
-                "nombre": "Come Rain Or Come Shine",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Autumn Leaves",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Witchcraft",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "When I Fall In Love",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "Peri's Scope",
-                "posicion": "A5"
-            },
-            {
-                "nombre": "What Is This Thing Called Love?",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Spring Is Here",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Someday My Prince Will Come",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Blue In Green",
-                "posicion": "B4"
-            }
-        ],
-        "artist": {
-            "nombre": "The Bill Evans Trio",
-            "nombre_real": "unasigned",
-            "perfil": "",
-            "url_imagen": "https://i.discogs.com/8rMdsQ-sOv6kgK5aUXprDd-CRNNeS6_r3_KHw_MbVpE/rs:fit/g:sm/q:90/h:535/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwMTE0/Ny0xNjM3NTQ5ODM5/LTM1MzEuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Bill Evans Trio* Featuring Scott La Faro* - Sunday At The Village Vanguard",
-            "url_imagen": "https://i.discogs.com/qzdI9vmF430nMwr3Ii2GrtYq800RzJgW9LJXD6LeSXY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEyNzY2/NTM5LTE1NDE1MzQ0/NTMtMzQ0MS5qcGVn.jpeg",
-            "sello": "RLP 376",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1961"
-        },
-        "tracklist": [
-            {
-                "nombre": "Gloria's Step",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "My Man's Gone Now",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Solar",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Alice In Wonderland",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "All Of You",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Jade Visions",
-                "posicion": "B3"
-            }
-        ],
-        "artist": {
-            "nombre": "The Bill Evans Trio",
-            "nombre_real": "unasigned",
-            "perfil": "",
-            "url_imagen": "https://i.discogs.com/8rMdsQ-sOv6kgK5aUXprDd-CRNNeS6_r3_KHw_MbVpE/rs:fit/g:sm/q:90/h:535/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwMTE0/Ny0xNjM3NTQ5ODM5/LTM1MzEuanBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "The Miles Davis Quintet - Steamin' With The Miles Davis Quintet",
-            "url_imagen": "https://i.discogs.com/S369DLRrzQKQqfw17_2bqWOOKJBZS_Vve-_FH98FEZ0/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE0ODgx/MzktMTI1MjQyNDA0/Mi5qcGVn.jpeg",
-            "sello": "7200",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1961",
-            "estilos": "Hard Bop"
-        },
-        "tracklist": [
-            {
-                "nombre": "Surrey With The Fringe On Top",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Salt Peanuts",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Something I Dreamed Last Night",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Diane",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Well You Needn't",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "When I Fall In Love",
-                "posicion": "B3"
-            }
-        ],
-        "artist": {
-            "nombre": "The Miles Davis Quintet",
-            "nombre_real": "unasigned",
-            "perfil": "The Miles Davis Quintet did not exist continously, but was formed several times with different basic line-ups. Mainly known are the two \"Great Quintets\".\r\n\r\n\"First Miles Davis Quintet\" or First Great Miles Davis Quintet\" - 1955 to 1958 with the following main artists (changes in line-up not shown here):\r\n    [a23755] — Trumpet\r\n    [a97545] — Tenor Saxophone\r\n    [a253641] — Piano\r\n    [a259778] — Double Bass\r\n    [a257251] — Drums\r\n    increased to Sextet in 1958 with [a61585] — Alto Saxophone \r\n\r\n\"Second Miles Davis Quintet\" or \"Second Great Miles Davis Quintet\" - 1964 to 1969 with the following main artists (changes in line-up not shown here):\r\n    [a23755] — Trumpet\r\n    [a29979] — Tenor Saxophone\r\n    [a3865] — Piano\r\n    [a95088] — Double Bass\r\n    [a261295] — Drums\r\n\r\nOutside these timespans there were also several Quintets besides the so called \"Great Quintets\". Several albums performed by the described Quintets are not credited to the group PAN, but to [a23755], please submit an \"Ensemble\" credit in these cases! (E.g. [r2882493])\r\n   ",
-            "url_imagen": "https://i.discogs.com/qtB0NTTCDDouLG2WfnI_f_eT48N0MleA1YUttVIXGHI/rs:fit/g:sm/q:90/h:336/w:444/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MjE1/Mi0xMzIyODE0NjU0/LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "The Incredible Jimmy Smith* - Back At The Chicken Shack",
-            "url_imagen": "https://i.discogs.com/OjMol0QYna52IPY4XBQRN3yTEZwobuNRLrGZ0Bd4QFI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIwMDU2/NDMtMTM1MjU3OTY0/Ny01MjAzLmpwZWc.jpeg",
-            "sello": "BLP 4117",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1963",
-            "estilos": "Hard Bop"
-        },
-        "tracklist": [
-            {
-                "nombre": "Back At The Chicken Shack",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "When I Grow Too Old To Dream",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Minor Chant",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Messy Bessie",
+                "nombre": "The Epic",
                 "posicion": "B2"
             }
         ],
         "artist": {
-            "nombre": "Jimmy Smith",
+            "id": 38210,
+            "nombre": "Pat Metheny Group",
             "nombre_real": "unasigned",
-            "perfil": "American jazz keyboardist, born 8 December 1928 in Norristown, Philadelphia, USA, died 8 February 2005 in Scottsdale, Arizona, USA (aged 76). He was married to [a313601]. Best known as a jazz musician who performed on the Hammond B-3 electric organ, which helped to popularize the instrument greatly. In 2005, Smith was awarded the NEA Jazz Masters Award from the National Endowment for the Arts, the highest honour that a US jazz musician can attain. \r\n\r\nFor the [l=Sun (9)] session pianist, see [a=Jimmy Smith (56)].",
-            "url_imagen": "https://i.discogs.com/b2QYLsHMEbcpEdB43h7wq3DZdkFzBUq9cuBfdXfSEnk/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI5OTgx/LTE0NTUzMzE2NTUt/NTE5OS5qcGVn.jpeg"
+            "perfil": "Jazz fusion band founded in 1977 around a core nucleus of guitarist [a=Pat Metheny] and keyboardist [a=Lyle Mays]. The line up has frequently changed over the years, but other long term members include bassist [a=Steve Rodby] and drummers [a=Danny Gottlieb] then [a=Paul Wertico].",
+            "url_imagen": "https://i.discogs.com/rJ_i_hE5o0QyYT8zZsRoBBRlHt4QcGrrxUqsKZyU5ww/rs:fit/g:sm/q:90/h:264/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM4MjEw/LTExMTUwNTcxMDYu/anBn.jpeg"
         }
     },
     {
         "release": {
+            "id": 21688,
             "titulo": "Weather Report - Sweetnighter",
             "url_imagen": "https://i.discogs.com/hX-g76kpjzs_eMvI-y6fbBFrpsx-LdvbsiiKkTZjMNg/rs:fit/g:sm/q:90/h:622/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ4MTAw/MS0xNDQwNDQ1MjE4/LTc4MDMuanBlZw.jpeg",
             "sello": "KC 32210",
@@ -2487,6 +2300,7 @@
             }
         ],
         "artist": {
+            "id": 10082,
             "nombre": "Weather Report",
             "nombre_real": "unasigned",
             "perfil": "American jazz fusion band with a career spanning between 1970 and 1986.",
@@ -2495,102 +2309,7 @@
     },
     {
         "release": {
-            "titulo": "Miles Davis - Bags' Groove",
-            "url_imagen": "https://i.discogs.com/m9beINTfGrqMpOdvpjXgRlDvAg4GbMH--6iOAm9vpQs/rs:fit/g:sm/q:90/h:595/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIzMTE5/NzktMTU1NTAwNDY1/Ni04MjY4LmpwZWc.jpeg",
-            "sello": "7109",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1957",
-            "estilos": "Bop, Hard Bop"
-        },
-        "tracklist": [
-            {
-                "nombre": "Bags' Groove (Take 1)",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Bags' Groove (Take 2)",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Airegin",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Oleo",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "But Not For Me (Take 2)",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Doxy",
-                "posicion": "B4"
-            },
-            {
-                "nombre": "But Not For Me (Take 1)",
-                "posicion": "B5"
-            }
-        ],
-        "artist": {
-            "nombre": "Miles Davis",
-            "nombre_real": "unasigned",
-            "perfil": "Trumpeter, bandleader, composer, and one of the most important figures in jazz music history, and music history in general. Davis adopted a variety of musical directions in a five-decade career that kept him at the forefront of many major stylistic developments in jazz. Winner of eight Grammy awards.\r\n\r\nBorn: 26 May 1926 in Alton, Illinois, USA.\r\nDied: 28 September 1991 in Santa Monica, California, USA (aged 65).\r\n\r\nBest known for his seminal modern jazz album \"[m=5460]\" (1959), the highest selling jazz album of all time with six million copies sold.\r\n\r\nMiles went to NYC to study at the academic school for musicians, where he met [a=Charlie Parker]. They started playing together from 1945. In 1948 Miles Davis started to make his own ensembles, at that time he met [a=Gil Evans], The Miles Davis Nonet was born. From the few recordings they made in 1949 to 1950 came the album \"[m=62308]\" (1957), with Davis and Evans going on to work more together in the future.\r\n\r\nMiles Davis was one of the musicians who introduced the 'Hard Bop' in the mid 1950s. In the late 1960s he started to experiment with electronic instruments and rock and funk rhythms. In the mid 1970s he stopped playing because of health problems, though in 1980 he made an 'electronical' comeback.\r\n\r\nInducted into Rock And Roll Hall of Fame in 2006 (Performer). Winner of Eight Grammy Awards.\r\n\r\nHe married dancer/actress [a=Frances Taylor Davis] on December 12, 1959; they divorced in 1968. He then married singer [a=Betty Mabry] in September 1968; they divorced in 1970. He then married actress [a=Cicely Tyson] on November 26, 1981; they divorced in 1989. Father of [a=Cheryl Davis] & [a=Erin Davis]. Uncle of [a=Vince Wilburn, Jr.]",
-            "url_imagen": "https://i.discogs.com/fvfSeynJ9rM5-55MQKikNuvvxxFpzVEcLZCls3-qRE0/rs:fit/g:sm/q:90/h:304/w:304/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIzNzU1/LTEzOTQzODczNDMt/NDUwMC5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "Ramsey Lewis - Sun Goddess",
-            "url_imagen": "https://i.discogs.com/pmbpjmxn0Qjl5tLq-U28zVCst342zkb6LRtLyOUSV8w/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwMzY4/NC0xNjMyMDg5NTcz/LTYxNTMuanBlZw.jpeg",
-            "sello": "KC 33194",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1974",
-            "estilos": "Soul-Jazz, Jazz-Funk"
-        },
-        "tracklist": [
-            {
-                "nombre": "Sun Goddess",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Living For The City",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Love Song",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Jungle Strut",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Hot Dawgit",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Tambura",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Gemini Rising",
-                "posicion": "B4"
-            }
-        ],
-        "artist": {
-            "nombre": "Ramsey Lewis",
-            "nombre_real": "unasigned",
-            "perfil": "American jazz pianist and keyboardist, born May 27, 1935 in Chicago, Illinois, USA, died September 12, 2022 in Chicago, Illinois, USA. ",
-            "url_imagen": "https://i.discogs.com/TMa35Ai0FvSqg2LdUJpG9xtfGruXnr_LptYOzIWTOR0/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTU1NzM4/LTE1MDU3NDQ5OTgt/MzYyMC5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
+            "id": 75645,
             "titulo": "John Coltrane - Coltrane's Sound",
             "url_imagen": "https://i.discogs.com/s85dlOK-IpiKFxCrn30xUuU66ta8OB_VPniLK9CJYWo/rs:fit/g:sm/q:90/h:614/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQwMzcy/MDgtMTY3MTc3MjA3/Ny04MzIyLnBuZw.jpeg",
             "sello": "SD 1419",
@@ -2627,6 +2346,7 @@
             }
         ],
         "artist": {
+            "id": 97545,
             "nombre": "John Coltrane",
             "nombre_real": "unasigned",
             "perfil": "American saxophonist and jazz composer.\r\n\r\nBorn: 23 September 1926 in Hamlet, North Carolina, USA.\r\nDied: 17 July 1967 in Huntington, Long Island, New York, USA (aged 40) from liver cancer.\r\n\r\nJohn Coltrane was one of the most influential musicians of the twentieth century. His early recordings capture a musician in the relatively conventional confines of bebop and hardbop, but his enduring legacy primarily rests on the modal jazz pioneered by his classic quartet (1960-64) and by free jazz explorations late in his career.\r\n\r\nHe recorded more than fifty albums as a leader and appeared as a sideman on many other albums, performing with other giants of jazz like [a=Miles Davis] and [a=Thelonious Monk]. Coltrane received numerous awards including a posthumous \"Special Citation\" from the Pulitzer Prize Board in 2007 for his 'masterful improvisation, supreme musicianship and iconic centrality to the history of jazz'.\r\n\r\nAs his life progressed, his music and outlook became increasingly spiritual. After his death he was proclaimed as a saint by the African Orthodox church that took his name.\r\n\r\nColtrane's second wife was pianist [a=Alice Coltrane]; their son [a=Ravi Coltrane] is also a saxophonist.",
@@ -2635,6 +2355,7 @@
     },
     {
         "release": {
+            "id": 62408,
             "titulo": "Chuck Mangione - Children Of Sanchez",
             "url_imagen": "https://i.discogs.com/iE28cD1dUOEd8pz9pfyXOBANlpyXJhNwbsaI6xbZPxU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYyMjk4/MC0xMTk3MDA1MDI0/LmpwZWc.jpeg",
             "sello": "SP-6700",
@@ -2707,6 +2428,7 @@
             }
         ],
         "artist": {
+            "id": 92051,
             "nombre": "Chuck Mangione",
             "nombre_real": "unasigned",
             "perfil": "American flugelhorn player and composer.\r\n\r\nBorn: 29 November 1940 in Rochester, New York, USA.\r\n\r\nBrother of pianist [a=Gap Mangione].",
@@ -2715,6 +2437,7 @@
     },
     {
         "release": {
+            "id": 47841,
             "titulo": "Herbie Hancock - Mr. Hands",
             "url_imagen": "https://i.discogs.com/9ji0MKupZRYBqqNDHUDknRXBTa96xxTD4UrAJOM22Ns/rs:fit/g:sm/q:90/h:594/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgzMjc0/MS0xNjUxNTE1NjA4/LTI1NDYuanBlZw.jpeg",
             "sello": "JC 36578",
@@ -2751,6 +2474,7 @@
             }
         ],
         "artist": {
+            "id": 3865,
             "nombre": "Herbie Hancock",
             "nombre_real": "unasigned",
             "perfil": "American jazz pianist, keyboardist, composer, band leader born April 12, 1940, in Chicago, Illinois, USA.\r\nHancock is one of the best-known modern jazz composers, creator of “Watermelon Man” (which has been a reference point throughout his career), “Maiden Voyage”, “Dolphin Dance”, right through to the dance grooves of “[r=3173760]”.",
@@ -2759,6 +2483,7 @@
     },
     {
         "release": {
+            "id": 21718,
             "titulo": "Weather Report - Night Passage",
             "url_imagen": "https://i.discogs.com/KsDE2CVQj9Ou49MqG4dtdbA9qQIw0GwgZGkLqGWATuI/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY4MTI1/MS0xNjg4MDYwNTQ5/LTU1ODcuanBlZw.jpeg",
             "sello": "JC 36793",
@@ -2803,6 +2528,7 @@
             }
         ],
         "artist": {
+            "id": 10082,
             "nombre": "Weather Report",
             "nombre_real": "unasigned",
             "perfil": "American jazz fusion band with a career spanning between 1970 and 1986.",
@@ -2811,6 +2537,7 @@
     },
     {
         "release": {
+            "id": 584654,
             "titulo": "Gabor Szabo - Dreams",
             "url_imagen": "https://i.discogs.com/tUtG9oF0Xx-ZQEWw2vgD-oLiFiWdZGGEnXhDBPmtyqw/rs:fit/g:sm/q:90/h:616/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNDY2/NDctMTU2NTkwMDM1/My0xMjUzLmpwZWc.jpeg",
             "sello": "SK-7",
@@ -2851,6 +2578,7 @@
             }
         ],
         "artist": {
+            "id": 22851,
             "nombre": "Gabor Szabo",
             "nombre_real": "unasigned",
             "perfil": "Hungarian jazz guitarist. \r\n\r\nBorn: 8 March 1936 in Budapest, Hungary. \r\nDied: 26 February 1982 in Budapest, Hungary (aged 45). \r\n\r\nAn influential jazz guitarist, famous for mixing jazz, pop-rock, and his native Hungarian music. Inspired by jazz music heard on Voice Of America radio broadcasts, Szabó began playing guitar at the age of 14. \r\n\r\nEscaping Hungary in 1956 and moving to the US where he attended the Berkeley School Of Music in Boston. In 1958, he was also invited to perform at the Newport Jazz Festival. Szabó then went on to perform with the quintet of southern California drummer [a=Chico Hamilton] from 1961 to 1965. \r\n\r\nBeginning in 1966, he recorded a well-received span of albums under his own name on the [l26557] label. In the late 1960s he co-founded the short-lived [l=Skye Records] label along with [a=Cal Tjader] and [a=Gary McFarland]. Later he signed with [l=Blue Thumb Records] and [l=CTI Records]. \r\n\r\nSzabó died in Budapest in 1982 from liver and kidney disease while on a visit to his homeland. \r\n",
@@ -2859,102 +2587,57 @@
     },
     {
         "release": {
-            "titulo": "Art Blakey & The Jazz Messengers - Indestructible",
-            "url_imagen": "https://i.discogs.com/lDKX8K1tk5HsK_nPhWEeIvTLoCiUhXlOVIpBlwKVxmc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1ODU5/MzUtMTMyNzM2MjY3/Ni5qcGVn.jpeg",
-            "sello": "BLP 4193",
+            "id": 176927,
+            "titulo": "Charles Mingus - Oh Yeah",
+            "url_imagen": "https://i.discogs.com/spu6zUHAgoMHMVWpQRDAuaFyN2SN6PSqwp2v11HYpHk/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTcwODc0/My0xNDI5OTYzNTMx/LTgwNDMuanBlZw.jpeg",
+            "sello": "1377",
             "formato": "Vinyl",
             "genero": "Jazz",
             "pais": "US",
-            "publicado": "1966",
-            "estilos": "Hard Bop"
+            "publicado": "1962",
+            "estilos": "Post Bop"
         },
         "tracklist": [
             {
-                "nombre": "The Egyptian",
+                "nombre": "Hog Callin' Blues",
                 "posicion": "A1"
             },
             {
-                "nombre": "Sortie",
+                "nombre": "Devil Woman",
                 "posicion": "A2"
             },
             {
-                "nombre": "Calling Miss Khadija",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "When Love Is New",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Mr. Jin",
-                "posicion": "B3"
-            }
-        ],
-        "artist": {
-            "nombre": "Art Blakey & The Jazz Messengers",
-            "nombre_real": "unasigned",
-            "perfil": "Archetypal hard-bop group of the late 1950s, most date their origin to 1954 or '55 when the first recordings credited to the band appeared.\r\nPlaying a driving, aggressive extension of bop with pronounced blues roots, the group continued until [url=http://www.discogs.com/artist/29977-Art-Blakey]Blakey[/url]'s death in 1990.\r\nThe name Jazz Messengers had been used by [a=Art Blakey] earlier, but when [a=Horace Silver] and [url=http://www.discogs.com/artist/29977-Art-Blakey]Blakey[/url]  began working together in the early 1950's the name had been dormant several years. The Jazz Messengers formed as a collective, nominally led by Silver or Blakey. Blakey credited Silver with reviving the Messengers name for the group. The original lineup of Blakey, Silver, [a=Hank Mobley], & [a=Kenny Dorham], was relatively shortlived. By late 1956 [a=Art Blakey] was the remaining original member.\r\nOver the years the Jazz Messengers served as a springboard for young jazz musicians, a proving ground for young jazz talent.",
-            "url_imagen": "https://i.discogs.com/pBilnAgQ5BkCMZglLOb--U1FV4TqAQCD2gJHphe5pPE/rs:fit/g:sm/q:90/h:286/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MjEy/OC0xMzMzNTUxMDQ4/LmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
-            "titulo": "The Dave Brubeck Quartet - Gone With The Wind",
-            "url_imagen": "https://i.discogs.com/mu082zAI-EL6eiPk996Dm8MCudb4-xFhItXOFeyylUs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMwMTU3/MzYtMTQ1OTkzMjcy/Ny0zMjU0LmpwZWc.jpeg",
-            "sello": "CS 8156",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1959",
-            "estilos": "Cool Jazz"
-        },
-        "tracklist": [
-            {
-                "nombre": "Swanee River",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "The Lonesome Road",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Georgia On My Mind",
+                "nombre": "Wham Bam Thank You Ma'am",
                 "posicion": "A3"
             },
             {
-                "nombre": "Camptown Races",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "Camptown Races",
+                "nombre": "Ecclusiastics",
                 "posicion": "B1"
             },
             {
-                "nombre": "Short'nin' Bread",
+                "nombre": "Oh Lord Don't Let Them Drop That Atomic Bomb On Me",
                 "posicion": "B2"
             },
             {
-                "nombre": "Basin Street Blues",
+                "nombre": "Eat That Chicken",
                 "posicion": "B3"
             },
             {
-                "nombre": "Ol' Man River",
+                "nombre": "Passions Of A Man",
                 "posicion": "B4"
-            },
-            {
-                "nombre": "Gone With The Wind",
-                "posicion": "B5"
             }
         ],
         "artist": {
-            "nombre": "The Dave Brubeck Quartet",
+            "id": 200815,
+            "nombre": "Charles Mingus",
             "nombre_real": "unasigned",
-            "perfil": "The Dave Brubeck Quartet was a jazz quartet founded in 1951 by [a37737] on piano together with [a170329] on saxophone. The Dave Brubeck Quartet disbanded in 1967, and only met again for its 25th anniversary in 1976. The band name would later be used by the pianist for other groups that he led.",
-            "url_imagen": "https://i.discogs.com/XZItdZIdStC8w9NR-ciPBapvWd7rq-Ue-ZHml2sbcPo/rs:fit/g:sm/q:90/h:347/w:432/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1MTY4/OS0xMzk5NzA1NDk5/LTQ0MDYuanBlZw.jpeg"
+            "perfil": "American jazz multi-instrumentalist, composer, bandleader, and civil rights activist. \r\n\r\nBorn: 22 April 1922 in Nogales, Arizona, USA. \r\nDied: 5 January 1979 in Cuernavaca, Mexico (aged 56). \r\n\r\nMingus was a forerunner in double bass technique, he also pioneered in overdubbing and cutting-up/reassembling tapes of different takes in the studio to achieve the best possible version to put on record. He also authored an autobiographical novel called \"Beneath The Underdog\". He died of Lou Gehrig's disease. \r\n",
+            "url_imagen": "https://i.discogs.com/kvUee0BO1G7uW9h-TB8m1Wd-NJXFcUeQQyh7kgIZiPs/rs:fit/g:sm/q:90/h:1065/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwMDgx/NS0xNjI5NDg0NzE3/LTE3NDEuanBlZw.jpeg"
         }
     },
     {
         "release": {
+            "id": 65076,
             "titulo": "Miles Davis - Miles Davis At Carnegie Hall",
             "url_imagen": "https://i.discogs.com/OKi2lUL_nDJ_7HKJ1IaPP9EdQbtrKJUT1xTZQH7s2IQ/rs:fit/g:sm/q:90/h:400/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxNDA0/NzktMTQ2NDUyNjY2/Mi01NDQ5LmpwZWc.jpeg",
             "sello": "CL 1812",
@@ -2991,6 +2674,7 @@
             }
         ],
         "artist": {
+            "id": 23755,
             "nombre": "Miles Davis",
             "nombre_real": "unasigned",
             "perfil": "Trumpeter, bandleader, composer, and one of the most important figures in jazz music history, and music history in general. Davis adopted a variety of musical directions in a five-decade career that kept him at the forefront of many major stylistic developments in jazz. Winner of eight Grammy awards.\r\n\r\nBorn: 26 May 1926 in Alton, Illinois, USA.\r\nDied: 28 September 1991 in Santa Monica, California, USA (aged 65).\r\n\r\nBest known for his seminal modern jazz album \"[m=5460]\" (1959), the highest selling jazz album of all time with six million copies sold.\r\n\r\nMiles went to NYC to study at the academic school for musicians, where he met [a=Charlie Parker]. They started playing together from 1945. In 1948 Miles Davis started to make his own ensembles, at that time he met [a=Gil Evans], The Miles Davis Nonet was born. From the few recordings they made in 1949 to 1950 came the album \"[m=62308]\" (1957), with Davis and Evans going on to work more together in the future.\r\n\r\nMiles Davis was one of the musicians who introduced the 'Hard Bop' in the mid 1950s. In the late 1960s he started to experiment with electronic instruments and rock and funk rhythms. In the mid 1970s he stopped playing because of health problems, though in 1980 he made an 'electronical' comeback.\r\n\r\nInducted into Rock And Roll Hall of Fame in 2006 (Performer). Winner of Eight Grammy Awards.\r\n\r\nHe married dancer/actress [a=Frances Taylor Davis] on December 12, 1959; they divorced in 1968. He then married singer [a=Betty Mabry] in September 1968; they divorced in 1970. He then married actress [a=Cicely Tyson] on November 26, 1981; they divorced in 1989. Father of [a=Cheryl Davis] & [a=Erin Davis]. Uncle of [a=Vince Wilburn, Jr.]",
@@ -2999,66 +2683,7 @@
     },
     {
         "release": {
-            "titulo": "Stan Getz – Joao Gilberto* - Getz / Gilberto #2",
-            "url_imagen": "https://i.discogs.com/DSOGuRE8J-XYIUnKlr1UFLZVa-wc-eo4i_8mNRWfW3Q/rs:fit/g:sm/q:90/h:536/w:547/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUzNjcx/MjAtMTM5MTY0Njkz/MS0xNzgxLmpwZWc.jpeg",
-            "sello": "V/8623",
-            "formato": "Vinyl",
-            "genero": "Jazz",
-            "pais": "US",
-            "publicado": "1966",
-            "estilos": "Swing, Bop, Latin Jazz, Bossa Nova"
-        },
-        "tracklist": [
-            {
-                "nombre": "Grandfather's Waltz",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Tonight I Shall Sleep With A Smile On My Face",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Stan's Blues",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Here's That Rainy Day",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "Samba Da Minha Terra",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Rosa Moreno",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "Um Abraco No Bonfa",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Bim Bom",
-                "posicion": "B4"
-            },
-            {
-                "nombre": "Meditation",
-                "posicion": "B5"
-            },
-            {
-                "nombre": "O Pato (The Duck)",
-                "posicion": "B6"
-            }
-        ],
-        "artist": {
-            "nombre": "Stan Getz",
-            "nombre_real": "unasigned",
-            "perfil": "Jazz saxophonist, born February 2, 1927, Philadelphia, Pennsylvania, USA - died June 6, 1991, Malibu, California, USA.",
-            "url_imagen": "https://i.discogs.com/RLwcssrTkzgtnFGN0cZwKcrND1FplpFQWwDazAeISMA/rs:fit/g:sm/q:90/h:456/w:457/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTMwNDg2/LTE2NTg5NDY0ODct/NTI1My5qcGVn.jpeg"
-        }
-    },
-    {
-        "release": {
+            "id": 84302,
             "titulo": "Yusef Lateef - Eastern Sounds",
             "url_imagen": "https://i.discogs.com/kquBiQTIn4YtMwmtW3w26h9j7wRXQSWyz8vxB2q3WBk/rs:fit/g:sm/q:90/h:598/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4MTUy/NzctMTU2NzYwNzMx/MC01OTQ3LmpwZWc.jpeg",
             "sello": "MV 22",
@@ -3107,6 +2732,7 @@
             }
         ],
         "artist": {
+            "id": 167055,
             "nombre": "Yusef Lateef",
             "nombre_real": "unasigned",
             "perfil": "American jazz musician, artist, composer, and producer. \r\n\r\nBorn: 9 October 1920 in Chattanooga, Tennessee, USA. \r\nDied: 23 December 2013 in Amherst, Massachusetts, USA (aged 93). \r\n\r\nLateef was a jazz multi-instrumentalist, composer and prominent figure among the Ahmadiyya Muslim Community in America, following his conversion to Islam in 1950. Although Lateef's main instruments were the tenor saxophone and flute, he also played oboe and bassoon, both rare in jazz, and also used a number of non-western instruments such as the bamboo flute, shanai, shofar, xun, arghul and koto. \r\n\r\nLateef had an inquisitive spirit and was never just a bop or hard bop soloist. He did not care much for the term \"jazz\", consistently creating music that stretched (and even broken through) boundaries. A superior tenor saxophonist with a soulful sound and impressive technique, by the 1950s Lateef was one of the top flutists around. He also developed into a talented jazz soloist on the oboe, was an occasional bassoonist, and introduced such instruments as the arghul (a double clarinet that resembles a bassoon), shanai (a type of oboe), and different types of flutes. \r\n\r\nLateef played \"world music\" long before the term was coined. \r\n",
@@ -3115,74 +2741,547 @@
     },
     {
         "release": {
-            "titulo": "Fleetwood Mac - Mr. Wonderful",
-            "url_imagen": "https://i.discogs.com/48f4TAFxy7kVib01pfsUHDy2ki2Ixa_Xuvxu3MfSsaw/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4NTg0/ODAtMTU0OTYxNDUy/MS0xNDk3LmpwZWc.jpeg",
-            "sello": "7-63205",
+            "id": 47927,
+            "titulo": "Herbie Hancock - V.S.O.P.",
+            "url_imagen": "https://i.discogs.com/3JOZpf2QQhFX7XNGr2T0Fn5sYYtdS_iQXrDuBlyB7So/rs:fit/g:sm/q:90/h:611/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUwMTgy/LTE0OTgzMzUyODEt/OTk4OS5qcGVn.jpeg",
+            "sello": "PG 34688",
             "formato": "Vinyl",
-            "genero": "Blues",
-            "pais": "UK",
-            "publicado": "1968",
-            "estilos": "Rhythm & Blues"
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1977",
+            "estilos": "Fusion, Post Bop, Jazz-Funk"
         },
         "tracklist": [
             {
-                "nombre": "Stop Messin' Round",
+                "nombre": "Piano Introduction",
                 "posicion": "A1"
             },
             {
-                "nombre": "I've Lost My Baby",
+                "nombre": "Maiden Voyage",
                 "posicion": "A2"
             },
             {
-                "nombre": "Rollin' Man",
+                "nombre": "Nefertiti",
                 "posicion": "A3"
             },
             {
-                "nombre": "Dust My Broom",
-                "posicion": "A4"
+                "nombre": "Introduction Of Players / Eye Of The Hurricane",
+                "posicion": "B"
             },
             {
-                "nombre": "Love That Burns",
-                "posicion": "A5"
+                "nombre": "Toys",
+                "posicion": "C1"
             },
             {
-                "nombre": "Doctor Brown",
-                "posicion": "A6"
+                "nombre": "Introductions",
+                "posicion": "C2"
             },
             {
-                "nombre": "Need Your Love Tonight",
-                "posicion": "B1"
+                "nombre": "You'll Know When You Get There",
+                "posicion": "C3"
             },
             {
-                "nombre": "If You Be My Baby",
-                "posicion": "B2"
+                "nombre": "Hang Up Your Hang Ups",
+                "posicion": "D1"
             },
             {
-                "nombre": "Evenin' Boogie",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Lazy Poker Blues",
-                "posicion": "B4"
-            },
-            {
-                "nombre": "Coming Home",
-                "posicion": "B5"
-            },
-            {
-                "nombre": "Trying So Hard To Forget",
-                "posicion": "B6"
+                "nombre": "Spider",
+                "posicion": "D2"
             }
         ],
         "artist": {
-            "nombre": "Fleetwood Mac",
+            "id": 3865,
+            "nombre": "Herbie Hancock",
             "nombre_real": "unasigned",
-            "perfil": "Founded in London in July 1967 (by ex-[url=http://www.discogs.com/artist/John+Mayall+%26+The+Bluesbreakers]Bluesbreakers[/url] members, Peter Green and Mick Fleetwood), \"Peter Green's Fleetwood Mac\" instantly became a major force in the UK blues scene, along with their eponymous first album. Following \"Mr. Wonderful\" & \"Then Play On\" the driving force of Peter Green had deteriorated as he lapsed into a personal crisis by 1970. The group reorganized, under the leadership of Fleetwood, and slowly took on a new direction - away from the blues and into the mainstream of international popularity, known simply as [b]Fleetwood Mac[/b].\r\n\r\nMember/Dates:\r\nPeter Green (guitar, vocals, 1967-70)\r\nMick Fleetwood (drums, 1967-1995, 1997-present)\r\nJohn McVie (bass, 1967-1995, 1997-present)\r\nJeremy Spencer (guitar, vocals, 1967-71)\r\nBob Brunning (bass, 1967)\r\nDanny Kirwan (guitar, 1968-72)\r\nChristine McVie (vocals, piano, accordion, 1970-1995, 1997-1998, 2014-2022)\r\nBob Welch (guitar, vocals, 1971-74)\r\nBob Weston (guitar, 1973-74)\r\nDave Walker (guitar, vocals, 1973)\r\nDoug Graves (keyboards, 1974)\r\nLindsey Buckingham (guitar, vocals, piano, 1975-87, 1993, 1997-2018)\r\nStevie Nicks (vocals, 1974–1991, 1993, 1997-present)\r\nBilly Burnette (guitar, vocals, 1990-94)\r\nRick Vito (guitar, 1990-91)\r\nDave Mason, (guitar, vocals, 1993-94)\r\nBekka Bramlett (vocals, 1993-94)\r\nMike Campbell (lead guitar, vocals, 2018–present)\r\nNeil Finn, (vocals, rhythm guitar, 2018–present)\r\n\r\nInducted into Rock And Roll Hall of Fame in 1998 (Performer)",
-            "url_imagen": "https://i.discogs.com/RmgxJXQV5jyibCGHQHnmKq3JsRWkhHE1P3t9rj_7O8E/rs:fit/g:sm/q:90/h:337/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQ3MzMz/LTE1NjY1NjE1NTIt/MjgxMS5qcGVn.jpeg"
+            "perfil": "American jazz pianist, keyboardist, composer, band leader born April 12, 1940, in Chicago, Illinois, USA.\r\nHancock is one of the best-known modern jazz composers, creator of “Watermelon Man” (which has been a reference point throughout his career), “Maiden Voyage”, “Dolphin Dance”, right through to the dance grooves of “[r=3173760]”.",
+            "url_imagen": "https://i.discogs.com/FsPFfIQgWkq60J41ShsFZG0B0kBu0xAFIbo8kx_m9Ys/rs:fit/g:sm/q:90/h:350/w:414/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM4NjUt/MTEwNTk4NjY3Mi5q/cGc.jpeg"
         }
     },
     {
         "release": {
+            "id": 214903,
+            "titulo": "Thelonious Monk Quartet* - Misterioso",
+            "url_imagen": "https://i.discogs.com/s8R5Uy5f1EsQwCGxBsDabzoUq94kdjSHsW2DBshA1oE/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNDI3/MjUtMTQ5ODg1MjE0/Ni0zMTI3LmpwZWc.jpeg",
+            "sello": "RLP 12-279",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1960",
+            "estilos": "Bop, Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Nutty",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Blues Five Spot",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Let's Cool One",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "In Walked Bud",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Just A Gigolo",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Misterioso",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "id": 261339,
+            "nombre": "The Thelonious Monk Quartet",
+            "nombre_real": "unasigned",
+            "perfil": "",
+            "url_imagen": "https://i.discogs.com/wrObXQKZFX-TUmqsaBtzAaEHu-8rTuX7YIQNYonhwJI/rs:fit/g:sm/q:90/h:197/w:252/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MTMz/OS0xMzMzNTUxMTk4/LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 39013,
+            "titulo": "Donald Byrd - Ethiopian Knights",
+            "url_imagen": "https://i.discogs.com/Kg3ES4Glivbv8TrJhgYJLJdFL5plFd5_M3Byx7AfNDM/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM0OTA2/MDYtMTMzOTAzNzAx/OC0zNzczLmpwZWc.jpeg",
+            "sello": "BST-84380",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1972",
+            "estilos": "Jazz-Funk"
+        },
+        "tracklist": [
+            {
+                "nombre": "The Emperor",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Jamie",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "The Little Rasti",
+                "posicion": "B"
+            }
+        ],
+        "artist": {
+            "id": 20956,
+            "nombre": "Donald Byrd",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz trumpeter, composer, bandleader and educator.\r\n\r\nBorn: 9 December 1932 in Detroit, Michigan, USA.\r\nDied: 4 February 2013 in Dover, Delaware, USA (aged 80).\r\n\r\nByrd attended Cass Tech, where he studied classical music and was mentored by the band director [a=Dr. Harry Begian], a disciplinarian. He played trumpet in military bands during a stint in the Air Force from 1951–1953, before graduating from Wayne State University in 1954 with a music degree. Like other young Detroit jazz musicians, he also studied with bebop pianist [a=Barry Harris (2)].\r\n\r\nByrd's warmly burnished sound, fluent technique and aggressive-yet-graceful swing was rooted in the style of Clifford Brown, but his gangly, rhythmically loose phrasing was a unique calling card right from the get-go. As Byrd matured in the late 1950s and early 1960s, he tempered his hummingbird flourishes with a cooler sensibility and phrasing.\r\n\r\nByrd recorded prolifically both as a sideman and a leader, appearing on scores of recordings on the [l=Savoy Records], [l=Prestige], [l=Riverside Records] and [l=Blue Note] labels. He led a feisty quintet with his old pal from Detroit, baritone saxophonist [a=Pepper Adams], from 1958–1961. Byrd also gave a young pianist from Chicago named [a=Herbie Hancock] his first major exposure by hiring him in 1961.\r\n\r\nAs a composer, Byrd was proficient in church-inspired shouts, funky and sophisticated blues forms and structurally interesting originals. He had a wider field of vision than many of his peers, exemplified by his influential 1963 LP, “A New Perspective” (Blue Note), which married his small group with a gospel choir.\r\n\r\nByrd never stopped going to school. He earned a master's degree in music education from the Manhattan School of Music in the late 1950s, studied composition with the famous classical pedagogue [a=Nadia Boulanger] in France in the early 1960s, earned a law degree from Howard University in 1976 and a doctorate from Columbia Teachers College in New York in the early 1980s.\r\n\r\nBeginning in the 1960s, Byrd taught at many universities, most notably Rutgers, Howard and North Carolina Central.\r\n\r\nBy the early 1970s, Byrd had begun exploring a danceable fusion of jazz, R&B and soul. In 1973, he teamed with current and former students at Howard, where he was chairman of the black music department, to make the best-selling LP “Black Byrd”. Produced by brothers [a=Larry Mizell & Fonce Mizell], the record and its sequels elevated Byrd into a crossover star.",
+            "url_imagen": "https://i.discogs.com/egoUwosfmZuiS_-_lqjMfR9tWjx5h7gqZpDaGkhjKBs/rs:fit/g:sm/q:90/h:533/w:504/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwOTU2/LTE1MjA5MjE0MzEt/NjUzOC5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 176935,
+            "titulo": "Charles Mingus, The Charles Mingus Jazz Workshop* - The Clown",
+            "url_imagen": "https://i.discogs.com/o1fwkTp2F9C477MSm7bY9B4muhpaNb-qUGpgUeS9iPc/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTg1ODQx/NC0xNTEzNzQ0MzA2/LTQ4NTMuanBlZw.jpeg",
+            "sello": "1260",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1957",
+            "estilos": "Post Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Haitian Fight Song",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Blue Cee",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Reincarnation Of A Lovebird",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "The Clown",
+                "posicion": "B2"
+            }
+        ],
+        "artist": {
+            "id": 200815,
+            "nombre": "Charles Mingus",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz multi-instrumentalist, composer, bandleader, and civil rights activist. \r\n\r\nBorn: 22 April 1922 in Nogales, Arizona, USA. \r\nDied: 5 January 1979 in Cuernavaca, Mexico (aged 56). \r\n\r\nMingus was a forerunner in double bass technique, he also pioneered in overdubbing and cutting-up/reassembling tapes of different takes in the studio to achieve the best possible version to put on record. He also authored an autobiographical novel called \"Beneath The Underdog\". He died of Lou Gehrig's disease. \r\n",
+            "url_imagen": "https://i.discogs.com/kvUee0BO1G7uW9h-TB8m1Wd-NJXFcUeQQyh7kgIZiPs/rs:fit/g:sm/q:90/h:1065/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTIwMDgx/NS0xNjI5NDg0NzE3/LTE3NDEuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 139442,
+            "titulo": "Diana Krall - All For You (A Dedication To The Nat King Cole Trio)",
+            "url_imagen": "https://i.discogs.com/g_SpLSrHaLm38TO_w2OGH-O6D1kp_PcNOHkiWIX5skk/rs:fit/g:sm/q:90/h:605/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxMjI1/MzktMTY0ODk1NTg0/My05ODk5LmpwZWc.jpeg",
+            "sello": "JTR 8458-2",
+            "formato": "CD",
+            "genero": "Jazz",
+            "pais": "Canada",
+            "publicado": "1996",
+            "estilos": "Contemporary Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "I'm An Errand Girl For Rhythm",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Gee Baby, Ain't I Good To You",
+                "posicion": "2"
+            },
+            {
+                "nombre": "You Call It Madness",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Frim Fram Sauce",
+                "posicion": "4"
+            },
+            {
+                "nombre": "Boulevard Of Broken Dreams",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Baby Baby All The Time",
+                "posicion": "6"
+            },
+            {
+                "nombre": "Hit That Jive Jack",
+                "posicion": "7"
+            },
+            {
+                "nombre": "You're Looking At Me",
+                "posicion": "8"
+            },
+            {
+                "nombre": "I'm Thru With Love",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Deed I Do",
+                "posicion": "10"
+            },
+            {
+                "nombre": "A Blossom Fell",
+                "posicion": "11"
+            },
+            {
+                "nombre": "If I Had You",
+                "posicion": "12"
+            },
+            {
+                "nombre": "When I Grow Too Old To Dream",
+                "posicion": "13"
+            }
+        ],
+        "artist": {
+            "id": 175483,
+            "nombre": "Diana Krall",
+            "nombre_real": "unasigned",
+            "perfil": "Award winning Canadian jazz pianist and singer, born November 16, 1964 in Nanaimo, British Columbia, Canada. She is married to [a=Elvis Costello]. Also a member of the Order Of Canada.",
+            "url_imagen": "https://i.discogs.com/_p_SK1488Q7MAlyL_qBF55eG78cLWtG5w3ZZ5cypHBc/rs:fit/g:sm/q:90/h:601/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE3NTQ4/My0xNTE0OTg5MzEw/LTMyNDYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 33133,
+            "titulo": "Jimmy Smith - Got My Mojo Workin'",
+            "url_imagen": "https://i.discogs.com/k9pDD7ZBO6QD5IIIMvdtbDD6UaZ9iMhOd9kC9qt2EuE/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIzNDU0/MTItMTYxNzExODcx/Ni03MjkwLmpwZWc.jpeg",
+            "sello": "V-8641",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1966",
+            "estilos": "Hard Bop, Bop, Soul-Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "High Heel Sneakers",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "(I Can't Get No) Satisfaction",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "1-2-3",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Mustard Greens",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Got My Mojo Workin'",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Johnny Come Lately",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "C Jam Blues",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Hobson's Hop",
+                "posicion": "B4"
+            }
+        ],
+        "artist": {
+            "id": 29981,
+            "nombre": "Jimmy Smith",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz keyboardist, born 8 December 1928 in Norristown, Philadelphia, USA, died 8 February 2005 in Scottsdale, Arizona, USA (aged 76). He was married to [a313601]. Best known as a jazz musician who performed on the Hammond B-3 electric organ, which helped to popularize the instrument greatly. In 2005, Smith was awarded the NEA Jazz Masters Award from the National Endowment for the Arts, the highest honour that a US jazz musician can attain. \r\n\r\nFor the [l=Sun (9)] session pianist, see [a=Jimmy Smith (56)].",
+            "url_imagen": "https://i.discogs.com/b2QYLsHMEbcpEdB43h7wq3DZdkFzBUq9cuBfdXfSEnk/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI5OTgx/LTE0NTUzMzE2NTUt/NTE5OS5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 62800,
+            "titulo": "Hank Mobley - No Room For Squares",
+            "url_imagen": "https://i.discogs.com/dWxyIT-rOHX2v4ZvzcOtiiHFYmbXnvEnvFB1Rj-rQMQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEyNDE0/NDYtMTM1MjE0MTc5/My04OTEzLmpwZWc.jpeg",
+            "sello": "BLP 4149",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1964",
+            "estilos": "Hard Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Three Way Split",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Carolyn",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Up A Step",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "No Room For Squares",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Me 'N You",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Old World, New Imports",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "id": 135872,
+            "nombre": "Hank Mobley",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz saxophonist (tenor),  composer and bandleader (born July 07, 1930 in Eastman, Georgia - died : May 30, 1986 in Philadelphia, Pennsylvania).\r\nPlayed with : Dizzy Gillespie, Max Roach, Art Blakey, Horace Silver, Doug Watkins, Kenny Dorham, Grant Green, Freddie Hubbard, Wynton Kelly, Sonny Clark, Philly Joe Jones, among others. \r\nHe recorded more than thirty albums as a leader, from 1955 to 1972, always accompanied by jazz musicians of the first order.\r\n",
+            "url_imagen": "https://i.discogs.com/nLrCjVEX8ynDrbOntiRjBOlWl9eC8sZkxyUIsofldRQ/rs:fit/g:sm/q:90/h:600/w:577/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzNTg3/Mi0xMzY3MTY2ODUy/LTk3MzAuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 352758,
+            "titulo": "Art Blakey And The Jazz Messengers* - Roots & Herbs",
+            "url_imagen": "https://i.discogs.com/FN8GVL-3dvogWINIPe8rgZ_JINUlo_sUIJUFvwsQxZQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI5NTI5/OTAtMTMyNzM2MjQ2/MS5qcGVn.jpeg",
+            "sello": "BST 84347",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1970",
+            "estilos": "Hard Bop, Modal"
+        },
+        "tracklist": [
+            {
+                "nombre": "Ping Pong",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Roots And Herbs",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "The Back Sliders",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "United",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Look At The Birdie",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Master Mind",
+                "posicion": "B3"
+            }
+        ],
+        "artist": {
+            "id": 262128,
+            "nombre": "Art Blakey & The Jazz Messengers",
+            "nombre_real": "unasigned",
+            "perfil": "Archetypal hard-bop group of the late 1950s, most date their origin to 1954 or '55 when the first recordings credited to the band appeared.\r\nPlaying a driving, aggressive extension of bop with pronounced blues roots, the group continued until [url=http://www.discogs.com/artist/29977-Art-Blakey]Blakey[/url]'s death in 1990.\r\nThe name Jazz Messengers had been used by [a=Art Blakey] earlier, but when [a=Horace Silver] and [url=http://www.discogs.com/artist/29977-Art-Blakey]Blakey[/url]  began working together in the early 1950's the name had been dormant several years. The Jazz Messengers formed as a collective, nominally led by Silver or Blakey. Blakey credited Silver with reviving the Messengers name for the group. The original lineup of Blakey, Silver, [a=Hank Mobley], & [a=Kenny Dorham], was relatively shortlived. By late 1956 [a=Art Blakey] was the remaining original member.\r\nOver the years the Jazz Messengers served as a springboard for young jazz musicians, a proving ground for young jazz talent.",
+            "url_imagen": "https://i.discogs.com/pBilnAgQ5BkCMZglLOb--U1FV4TqAQCD2gJHphe5pPE/rs:fit/g:sm/q:90/h:286/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MjEy/OC0xMzMzNTUxMDQ4/LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 120708,
+            "titulo": "Thelonious Monk - Genius Of Modern Music Volume 2",
+            "url_imagen": "https://i.discogs.com/2Z7-lswREhhe_tbQQtL5KtBkNukq7M2KIObhVltGPpY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU4MjQ5/NzAtMTQwMzcyMDI1/MS0xNzQ1LmpwZWc.jpeg",
+            "sello": "BLP 1511",
+            "formato": "Vinyl",
+            "genero": "Jazz",
+            "pais": "US",
+            "publicado": "1956",
+            "estilos": "Bop"
+        },
+        "tracklist": [
+            {
+                "nombre": "Carolina Moon",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Hornin' In",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Skippy",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Let's Cool One",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Suburban Eyes",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Evonce",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "Straight No Chaser",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Four In One",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Nice Work",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Monk's Mood",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Who Knows",
+                "posicion": "B5"
+            },
+            {
+                "nombre": "Ask Me Now",
+                "posicion": "B6"
+            }
+        ],
+        "artist": {
+            "id": 145256,
+            "nombre": "Thelonious Monk",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz pianist and composer.\r\n\r\nBorn: 10 October 1917 in Rocky Mount, North Carolina, USA.\r\nDied: 17 February 1982 in Weehawken, New Jersey, USA (aged 64).\r\n\r\nOne of the most influential pianists of the twentieth century, Thelonious Monk had a idiosyncratic improvisational style and made numerous contributions to the standard jazz repertoire. He is often regarded as one of the founders of bebop. Monk's prolific compositions and improvisations are full of dissonant harmonies and angular melodic twists.  His  unorthodox approach to the piano combines a highly percussive attack with abrupt, use of silence and dramatic pauses. He was also known for a distinct fashion sense in his suits, hats and trademark sunglasses. Monk was an unconventional stage presence, known for getting up from his piano to dance (sometimes in a counter-clockwise motion  which drew comparisons to ring-shout and Muslim Sufi whirling) while his band members were still playing. Monk is one of only five jazz musicians to date to be featured on the cover of Time magazine, which puts him in a select company with [a=Louis Armstrong], [a=Duke Ellington], [a=Wynton Marsalis], and [a=Dave Brubeck].\r\n\r\nFather of [a=Thelonious Monk Jr.] and [a=Boo Boo Monk].",
+            "url_imagen": "https://i.discogs.com/le-f8Rp9W52kDeHOhEPs9yOpWYgIO4B6ww2CWHVTKW8/rs:fit/g:sm/q:90/h:480/w:322/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE0NTI1/Ni0xMTYwNjgyNjgx/LmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 52876,
+            "titulo": "Charlie Haden & Pat Metheny - Beyond The Missouri Sky (Short Stories)",
+            "url_imagen": "https://i.discogs.com/l5aSrn6nEIVC-FOdV5WcZmmrFIMjHGxkwS_QyoCG6mU/rs:fit/g:sm/q:90/h:538/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxMDg3/Ni0xNDc3Nzc3ODM4/LTE4OTQuanBlZw.jpeg",
+            "sello": "537 130-2",
+            "formato": "CD",
+            "genero": "Jazz",
+            "pais": "Europe",
+            "publicado": "1997",
+            "estilos": "Contemporary Jazz"
+        },
+        "tracklist": [
+            {
+                "nombre": "Waltz For Ruth",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Our Spanish Love Song",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Message To A Friend",
+                "posicion": "3"
+            },
+            {
+                "nombre": "Two For The Road",
+                "posicion": "4"
+            },
+            {
+                "nombre": "First Song (For Ruth)",
+                "posicion": "5"
+            },
+            {
+                "nombre": "The Moon Is A Harsh Mistress",
+                "posicion": "6"
+            },
+            {
+                "nombre": "The Precious Jewel",
+                "posicion": "7"
+            },
+            {
+                "nombre": "He's Gone Away",
+                "posicion": "8"
+            },
+            {
+                "nombre": "The Moon Song",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Tears Of Rain",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Cinema Paradiso (Love Theme)",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Cinema Paradiso (Main Theme)",
+                "posicion": "12"
+            },
+            {
+                "nombre": "Spiritual",
+                "posicion": "13"
+            }
+        ],
+        "artist": {
+            "id": 253592,
+            "nombre": "Charlie Haden",
+            "nombre_real": "unasigned",
+            "perfil": "American jazz double bassist. Born August 6, 1937 in Shenandoah, Iowa, USA; died July 11, 2014 in Los Angeles, CA, USA. Married to [a=Ruth Cameron Haden].\r\nFather of [a=Josh Haden], [a=Petra Haden], [a=Tanya Haden] & [a=Rachel Haden]; father-in-law of [a=Jack Black (2)] (Tanya's husband).",
+            "url_imagen": "https://i.discogs.com/jOeJxsxS8JlGBI13hjc7IIEMSfgmt5LSCvHsB64jsJQ/rs:fit/g:sm/q:90/h:718/w:560/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI1MzU5/Mi0xNTcwNjkzMTgw/LTQ5NjYuanBlZw.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 93917,
             "titulo": "Johnny Winter - Nothin' But The Blues",
             "url_imagen": "https://i.discogs.com/l6-GOXpLj5Fvrgi8cZtkBxChjaz4YP4_DgXXRdER7ZE/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk0Njcy/MS0xMzY2NzkyMjc3/LTMzOTIuanBlZw.jpeg",
             "sello": "PZ 34813",
@@ -3231,6 +3330,7 @@
             }
         ],
         "artist": {
+            "id": 254198,
             "nombre": "Johnny Winter",
             "nombre_real": "unasigned",
             "perfil": "American blues guitarist and singer (born February 23, 1944 in Beaumont, Texas USA - died July 16, 2014 in Zurich, Switzerland).\r\n\r\nHis first instruments were the clarinet and the ukulele, settling on guitar by age eleven. Something of a musical child prodigy, he grew up in Beaumont, Texas, on a diet of blues and rock 'n' roll. As a teen, nearly every weekend he would hitch-hike to Louisiana to play in small night clubs. After a short college stint, he gave up his academic pursuits and devoted himself to creating music.\r\nHe signed a five year contract with Columbia Records in 1969 (for $300,000) and the rest is history. Before signing to Columbia he recorded one album (two if you consider 'First Winter' als a proper album) and lots of singles, under his own name or as sideman. These have been repackaged and compiled at infinite.\r\n\r\nOlder brother of [a=Edgar Winter].\r\n",
@@ -3239,6 +3339,7 @@
     },
     {
         "release": {
+            "id": 67562,
             "titulo": "George Thorogood And The Destroyers* - Better Than The Rest",
             "url_imagen": "https://i.discogs.com/h0iWlw0HXUMW3BB-ytHZ2hvldrYbaWlGlRSDnoAXKrE/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTg2NDUz/Ni0xNTk4OTY3ODk5/LTMyMjQuanBlZw.jpeg",
             "sello": "MCA-3091",
@@ -3291,6 +3392,7 @@
             }
         ],
         "artist": {
+            "id": 258120,
             "nombre": "George Thorogood & The Destroyers",
             "nombre_real": "unasigned",
             "perfil": "",
@@ -3299,6 +3401,7 @@
     },
     {
         "release": {
+            "id": 145439,
             "titulo": "R.L. Burnside - Too Bad Jim",
             "url_imagen": "https://i.discogs.com/04sB6PeZPFcMVurf3_uufXURY5RCVyqrkxoYCoVxwJs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEzMTEy/MDM4LTE2MjU2MzE2/NDYtNTc3OC5qcGVn.jpeg",
             "sello": "80307-1",
@@ -3351,6 +3454,7 @@
             }
         ],
         "artist": {
+            "id": 262901,
             "nombre": "R.L. Burnside",
             "nombre_real": "unasigned",
             "perfil": "Born: November 21, 1926, either Harmontown, College Hill or Blackwater Creek all of which are in the rural part of Lafayette County, Mississippi\r\nDied: September 1, 2005, Memphis, Tennessee; buried at Free Springs Cemetery in Harmontown, MS.\r\n\r\nHis first name is given as R.L., Rural (which is on his tombstone), Robert Lee, Rule, or Ruel.  His father left him early on and he grew up in his large family including his mother, grandparents and several siblings.  Started playing harmonica and guitar at age 16 learning from Mississippi Fred McDowelll.  R.L. credited Muddy Waters, Lightnin' Hopkins and John Lee Hooker as influences.  Muddy Waters was his cousin-in-law.  While living in Chicago in the late-1940's his father and two uncles were murdered in the same year which he sang about and referenced often in his songs.  He returned to Mississippi and working through the 1980's as a sharecropper and a commercial fisherman selling what he caught door-to-door.  He started to receive recognition in the 1990's.\r\n\r\nFather of [a4801571]\r\nFather-in-law of [a2018914]\r\nGrandfather of [a384455]",
@@ -3359,6 +3463,7 @@
     },
     {
         "release": {
+            "id": 269312,
             "titulo": "B.B. King - L.A. Midnight",
             "url_imagen": "https://i.discogs.com/EdaMN49TskpYdJ7eOqTzCWtic5lEtUjGOFctQicO8AA/rs:fit/g:sm/q:90/h:470/w:450/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE4OTI1/NTMtMTQxMTQ4ODAz/MS04MzUxLmpwZWc.jpeg",
             "sello": "SPB 1051",
@@ -3398,6 +3503,7 @@
             }
         ],
         "artist": {
+            "id": 37729,
             "nombre": "B.B. King",
             "nombre_real": "unasigned",
             "perfil": "American blues singer, guitarist, and songwriter (September 16, 1925 near Itta Bena, Mississippi - May 14, 2015, Las Vegas, Nevada). \r\nB.B. is an abbreviation for 'Blues Boy'.\r\n\r\nKing is one of the most influential blues musicians of all time, earning the nickname \"The King of the Blues.\" He is considered one of the \"Three Kings of the Blues Guitar\" (along with [a=Albert King] and [a=Freddie King], none of whom are related). Since he started recording in the 1940s, he released over fifty albums. He previously worked as a tractor driver.\r\n\r\nIn his youth, he played on street corners for dimes, and would sometimes play in as many as four towns a night. In 1947, he hitchhiked to Memphis, TN, to pursue his music career. In Memphis, B.B. stayed with his cousin [a=Bukka White], one of the most celebrated blues performers of his time, who B.B. credits as one of his earliest mentors and teachers. King's first big break came in 1948 when he performed on [a=Sonny Boy Williamson]’s radio program on KWEM out of West Memphis. This radio performance led to steady engagements at the Sixteenth Avenue Grill in West Memphis and later to a ten-minute spot on the Memphis radio station WDIA. King's radio spot become so popular, it was expanded and became the “Sepia Swing Club.” As King worked at WDIA as a singer and disc jockey, he was given the catchy radio nickname \"Beale Street Blues Boy\", later shortened to \"Blues Boy\", and finally to \"B.B.\" \r\n\r\nIn the late 1940s and early 1950s, King was a part of the blues scene on Beale Street. \"Beale Street was where it all started for me\", King said. He performed with [a=Bobby Bland], [a=Johnny Ace], and [a=Earl Forest] in a group known as [a=The Beale Streeters]. In 1949, King made his recording debut on [l=Bullet (2)] ([l=Bullet Recording & Transcription Co.]) by issuing the single [url=https://www.discogs.com/release/7031392-BB-King-Miss-Martha-King-When-Your-Baby-Packs-Up-And-Goes]\"Miss Martha King\"[/url], which did not chart well. Later that year, he began a recording contract with Los Angeles-based [l=RPM Records (5)]. Many of King's early recordings were produced by [a=Sam Phillips (2)] (who later founded [l=Sun Record Company]). King's recording contract was followed by tours across the US, with performances in big city theatres as well as gigs in small clubs and juke joints in the southern United States. During one show in Twist, Arkansas, a fight broke out between two men and caused a fire. King evacuated with the rest of the crowd, but realizing he left his acoustic guitar inside, rushed back inside the burning building to retrieve it. He later discovered the two men were fighting over a woman named Lucille. Ever since, each one of B.B.’s trademark Gibson guitars has been called Lucille, as a reminder not to fight over women or run into any more burning buildings. \r\n\r\nIn 1952, B.B. had a number one hit with “Three O’Clock Blues,” and began touring nationally soon after. 1956 became a record-breaking year, with 342 concerts booked and three recording sessions. That same year he founded his own record label, [l=Blues Boys Kingdom], with headquarters at Beale Street in Memphis. In 1962, King signed to [l=ABC-Paramount] Records, which was later absorbed into [l=MCA Records]. In November 1964, King recorded the [m=107099] album, considered to be one of his finest recordings. In 1968, B.B. played at the [l=Newport Folk Festival] and at [a=Bill Graham (2)]’s [l=Fillmore West] on bills with the hottest contemporary rock artists of the day who idolized B.B. and helped to introduce him to a young white audience. In 1969, B.B. was chosen by [a=The Rolling Stones] as the opening act for their American tour. He won a 1970 Grammy Award for his version of the song \"The Thrill Is Gone\", which was a hit on both the Pop and R&B charts. It also gained the number 183 spot in Rolling Stone magazine's 500 Greatest Songs of All Time. From the 1980s until his death in 2015, he maintained a highly visible and active career, appearing on numerous television shows and performing as much as 300 nights a year.\r\n\r\nB.B. was inducted into the Blues Foundation Hall of Fame in 1984 and into the Rock And Roll Hall of Fame in 1987 (Performer).",
@@ -3406,6 +3512,73 @@
     },
     {
         "release": {
+            "id": 173383,
+            "titulo": "John Lee Hooker - Burnin'",
+            "url_imagen": "https://i.discogs.com/fBUD9Vrp7IbotT1YfY53bAMSNI6_yfltkmvqqLuJRms/rs:fit/g:sm/q:90/h:478/w:481/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI4MjUz/NTAtMTMwNzEyMTIw/NS5qcGVn.jpeg",
+            "sello": "VJLP 1043",
+            "formato": "Vinyl",
+            "genero": "Blues",
+            "pais": "US",
+            "publicado": "1962",
+            "estilos": "Chicago Blues, Rhythm & Blues"
+        },
+        "tracklist": [
+            {
+                "nombre": "Boom Boom",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Process",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Lost A Good Girl",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "A New Leaf",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Blues Before Sunrise",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Let's Make It",
+                "posicion": "A6"
+            },
+            {
+                "nombre": "I Got A Letter",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Thelma",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "Drug Store Woman",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "Keep Your Hands To Yourself",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "What Do You Say",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "id": 94557,
+            "nombre": "John Lee Hooker",
+            "nombre_real": "unasigned",
+            "perfil": "American blues singer-songwriter and guitarist.\r\nBorn: August 22, 1912 in Tutwiler, Tallahatchie County, Mississippi, USA.\r\nDied: June 21, 2001 in Los Altos, California, USA.\r\n\r\nSome of his best known songs include \"Boogie Chillen'\" (1948), \"Crawling King Snake\" (1949), \"Dimples\" (1956), \"Boom Boom\" (1962), and \"One Bourbon, One Scotch, One Beer\" (1966). Several of his later albums, including The Healer (1989), Mr. Lucky (1991), Chill Out (1995), and Don't Look Back (1997), were album chart successes in the U.S. and UK.\r\n\r\nInducted into Rock And Roll Hall of Fame in 1991 (Performer).",
+            "url_imagen": "https://i.discogs.com/LsQ3wwUAxYVkj0X2KkLCi4FbABhPdskItIza2FpbFXg/rs:fit/g:sm/q:90/h:583/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk0NTU3/LTE1ODIxMzE5MDYt/NDcwMi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 460009,
             "titulo": "John Lee Hooker - That's My Story: John Lee Hooker Sings The Blues",
             "url_imagen": "https://i.discogs.com/Bb83qA6P9m8rJSboc9poPyP0YP0vs_bJ3k6HCzymC78/rs:fit/g:sm/q:90/h:391/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTQ1NTQx/NzMtMTM2ODIwNTE2/Ni04MjIwLmpwZWc.jpeg",
             "sello": "12-321",
@@ -3466,6 +3639,7 @@
             }
         ],
         "artist": {
+            "id": 94557,
             "nombre": "John Lee Hooker",
             "nombre_real": "unasigned",
             "perfil": "American blues singer-songwriter and guitarist.\r\nBorn: August 22, 1912 in Tutwiler, Tallahatchie County, Mississippi, USA.\r\nDied: June 21, 2001 in Los Altos, California, USA.\r\n\r\nSome of his best known songs include \"Boogie Chillen'\" (1948), \"Crawling King Snake\" (1949), \"Dimples\" (1956), \"Boom Boom\" (1962), and \"One Bourbon, One Scotch, One Beer\" (1966). Several of his later albums, including The Healer (1989), Mr. Lucky (1991), Chill Out (1995), and Don't Look Back (1997), were album chart successes in the U.S. and UK.\r\n\r\nInducted into Rock And Roll Hall of Fame in 1991 (Performer).",
@@ -3474,6 +3648,7 @@
     },
     {
         "release": {
+            "id": 365026,
             "titulo": "Robert Johnson - The Complete Collection",
             "url_imagen": "https://i.discogs.com/LU2WXZAvpS46NIkwLTx7ZMdUUQic4brdnjPneyrj_EI/rs:fit/g:sm/q:90/h:518/w:519/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5NzMw/MjktMTI1NTk3ODUz/MS5qcGVn.jpeg",
             "sello": "PLATCD 278",
@@ -3602,6 +3777,7 @@
             }
         ],
         "artist": {
+            "id": 272142,
             "nombre": "Robert Johnson",
             "nombre_real": "unasigned",
             "perfil": "Legendary, influential delta blues guitarist, singer and songwriter.\r\nBorn: May 8, 1911, Hazlehurst, Mississippi\r\nDied: August 16, 1938, Greenwood, Mississippi\r\n\r\nPassed away at 27, leaving a widespread impact on music. Some of his songs have been credited to [a=Woody Payne (2)], also known as [a=T Colley]. Inducted into Rock And Roll Hall of Fame in 1986 (Early Influence).\r\n\r\nFather of [a13326465].\r\n\r\n[b]Note: For the [a=KC & The Sunshine Band] drummer, please use [a=Robert Johnson (3)].\r\nFor the English composer from the Renaissance, please use [a=Robert Johnson (9)].[/b]",
@@ -3610,6 +3786,7 @@
     },
     {
         "release": {
+            "id": 392930,
             "titulo": "Freddie King - My Feeling For The Blues",
             "url_imagen": "https://i.discogs.com/qVvEWmhgq7Q26i6Xu-suIe-9HDFDILZFnewyrncO6OA/rs:fit/g:sm/q:90/h:413/w:399/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMwNTcz/OTQtMTM0MDIwMTcy/My00NDEyLmpwZWc.jpeg",
             "sello": "SD 9016",
@@ -3666,6 +3843,7 @@
             }
         ],
         "artist": {
+            "id": 323162,
             "nombre": "Freddie King",
             "nombre_real": "unasigned",
             "perfil": "American blues guitarist and singer.\r\nBorn September 3, 1934 in Gilmer, Texas, died December 28, 1976 in Dallas, Texas. \r\nHe moved to Chicago, Illinois, in 1949. In 1956 he cut his first record as a leader. Later he was one of the first bluesmen to have a multi-racial backing band at live performances. Freddie King is often mentioned as one of “the three kings” of electric blues guitar along with Albert King and B.B. King (no relation).\r\nIn 1993 by proclamation from the Texas Governor Ann Richards,  September 3 was declared the Freddie King Day. Freddie King placed 15th in Rolling Stone magazine’s list of the 100 greatest guitarists of all time. In 2012, he was inducted into the Rock and Roll Hall of Fame.",
@@ -3674,6 +3852,7 @@
     },
     {
         "release": {
+            "id": 264818,
             "titulo": "Hound Dog Taylor And The HouseRockers* - Natural Boogie",
             "url_imagen": "https://i.discogs.com/ohBSfGnxFUqPnZjZjF2UGfAYTfhaq7Vms86XCq8A550/rs:fit/g:sm/q:90/h:596/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE2MjIz/MTAtMTM4NTY2MTM0/NC0yNzEyLmpwZWc.jpeg",
             "sello": "AL 4704",
@@ -3730,6 +3909,7 @@
             }
         ],
         "artist": {
+            "id": 489663,
             "nombre": "Hound Dog Taylor & The House Rockers",
             "nombre_real": "unasigned",
             "perfil": "Hound Dog's band.\r\nMembers:\r\nHound Dog Taylor - Lead & Slide Guitar and Vocals\r\nBrewer Phillips - Second Guitar\r\nTed Harvey - Drums\r\n",
@@ -3738,6 +3918,7 @@
     },
     {
         "release": {
+            "id": 447746,
             "titulo": "Various - The Blues World Of Eric Clapton",
             "url_imagen": "https://i.discogs.com/etSEb23EAhU1wsi2jr7NAaEqMF47qe9SwmWTiG4tx2U/rs:fit/g:sm/q:90/h:500/w:491/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYxNzMy/NDItMTQxMjg4ODY5/MS0zMjU1LmpwZWc.jpeg",
             "sello": "SPAI 387",
@@ -3797,6 +3978,7 @@
             }
         ],
         "artist": {
+            "id": 489663,
             "nombre": "Hound Dog Taylor & The House Rockers",
             "nombre_real": "unasigned",
             "perfil": "Hound Dog's band.\r\nMembers:\r\nHound Dog Taylor - Lead & Slide Guitar and Vocals\r\nBrewer Phillips - Second Guitar\r\nTed Harvey - Drums\r\n",
@@ -3805,6 +3987,7 @@
     },
     {
         "release": {
+            "id": 190230,
             "titulo": "Buddy Guy - The Blues Giant",
             "url_imagen": "https://i.discogs.com/Xy44-g8Ex-7u1VMHwWyQsvB-HS-5xex60AiE8RaYwzE/rs:fit/g:sm/q:90/h:593/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc3OTIz/Ni0xNjUyMDkxNjky/LTM2MzYuanBlZw.jpeg",
             "sello": "900.500",
@@ -3841,6 +4024,7 @@
             }
         ],
         "artist": {
+            "id": 259799,
             "nombre": "Buddy Guy",
             "nombre_real": "unasigned",
             "perfil": "American blues guitarist and singer, born July 30th, 1936 in Lettsworth, Louisiana, and one of the pioneers of the Chicago blues sound. Began performing with bands in Baton Rouge in the '50s before moving to Chicago in 1957. He originally recorded for [l=Cobra Record Corp.] subsidiary [l=Artistic (2)] before moving to [l=Chess], where he worked as a sideman and leader when Cobra folded. During his time on Chess he also recorded under the pseudonym Friendly Chap for [l=Delmark Records]. He moved to [l=Vanguard] in 1967, and then went on to work with a variety of labels. He is the brother of [a=Phil Guy].\r\n\r\nGuy has won six Grammy awards, 23 W.C. Handy Awards, and, in 2003, he was awarded the National Medal of Arts. He was inducted into the Rock And Roll Hall of Fame in 2005, and into the Louisiana Music Hall of Fame in 2008.",
@@ -3849,6 +4033,7 @@
     },
     {
         "release": {
+            "id": 256972,
             "titulo": "Muddy Waters - The Real Folk Blues",
             "url_imagen": "https://i.discogs.com/qbW8ckFeBzHJzyYSDdwH0ChaPVdvi0hiXNxcoO0ZRKk/rs:fit/g:sm/q:90/h:559/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY5Njc3/MzEtMTQzMDYxNzc1/NS01MzY4LmpwZWc.jpeg",
             "sello": "LP-1501",
@@ -3908,6 +4093,7 @@
             }
         ],
         "artist": {
+            "id": 59246,
             "nombre": "Muddy Waters",
             "nombre_real": "unasigned",
             "perfil": "American blues guitarist, singer and composer.\r\nBorn 4 April 1913, Rolling Fork, Mississippi, USA.\r\nDied 30 April 1983, Westmont, Illinois, USA.\r\n\r\nFather of [a4092559], [a1965346], and [a10232473] (died December 10, 2020, aged 56).\r\n\r\nConsidered by many to be a founder of the modern Chicago Blues style. A powerful inspiration in the emergence of the electric blues-oriented groups in the UK during the '60s. He became the most prominent interpreter of the electric blues.\r\n\r\nOn Morganfield's marriage license and Musician's Union card, he indicates the year of his birth as 1913. His place of birth was, in fact, in Issaquena County near Rolling Fork, Mississippi. However, his gravestone remains dated as 1915.\r\n\r\nMorganfield was inducted into the 'Rock And Roll Hall of Fame' in 1987 (Performer).",
@@ -3916,6 +4102,7 @@
     },
     {
         "release": {
+            "id": 268698,
             "titulo": "Howling Wolf* - Howling Wolf Sings The Blues",
             "url_imagen": "https://i.discogs.com/FIbxiwqDE5g4sHjN4SGJKCQ21dR58iLEAMHJ9YKRFgs/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM2OTI3/ODQtMTQ1MTA3NTE4/Mi00NDI3LmpwZWc.jpeg",
             "sello": "CLP 5240",
@@ -3968,6 +4155,7 @@
             }
         ],
         "artist": {
+            "id": 340678,
             "nombre": "Howlin' Wolf",
             "nombre_real": "unasigned",
             "perfil": "Blues singer, guitarist, harmonica player. A key figure in bridging the early Delta Blues with the more modern Electric Blues. His tutelage on the Mississippi Delta included guitar and showmanship from [a=Charley Patton] and harmonica teachings from [a=Sonny Boy Williamson (2)]. By the end of the 1930's he was a fixture on the Southern Club scene. He was inducted into the U.S. Army on April 9, 1941 and discharged on November 3, 1943. He then moved near West Memphis, Arkansas. In 1948 he formed a band which included guitarists [a=Willie Johnson (4)] & [url=https://www.discogs.com/artist/348055-Matt-Murphy]Matt \"Guitar\" Murphy[/url], harmonica player [a=Little Junior Parker], and drummer [a=Willie Steele (2)]. In 1951, [a=Sam Phillips (2)] recorded several songs by Howlin' Wolf at his [l=Memphis Recording Service], and he became a local celebrity. After [a=Leonard Chess] secured his contract, The Wolf relocated to Chicago in 1952. It was in Chicago that his legendary status was secured. Playing with prominent blues musicians such as [a=Willie Dixon],  [a=Jimmy Rogers] and his longtime guitarist [a=Hubert Sumlin], his everchanging lineups remained stellar thanks in part to Burnetts' admirable policies of paying his musicians well and on time, even including unemployment insurance and Social Security contributions, basically unheard of among his peers. Over the years many of his songs have been interpreted by rock bands, including  \"Little Red Rooster\", \"Back Door Man\", \"Killing Floor\", & \"Spoonful\".  [a=Howlin Wolf], with his Memphis and Chicago recordings, his status and influence, surely is one of the vital links between Blues and Rock.\r\n\r\nInducted into Rock And Roll Hall of Fame in 1991 (Early Influence).\r\n\r\nBorn June 10, 1910 West Point, Mississippi, USA.\r\nDied January 10, 1976 Hines, Illinois, USA.",
@@ -3976,6 +4164,7 @@
     },
     {
         "release": {
+            "id": 420666,
             "titulo": "Mississippi John Hurt - The Best Of Mississippi John Hurt",
             "url_imagen": "https://i.discogs.com/ImNO7rmtIrutNw4IkipeDkQbLxyYyn3Bp4adxasIkeA/rs:fit/g:sm/q:90/h:500/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY4MDUw/Mi0xMjY1NzQ1MzY2/LmpwZWc.jpeg",
             "sello": "VSD 19/20",
@@ -4072,6 +4261,7 @@
             }
         ],
         "artist": {
+            "id": 307249,
             "nombre": "Mississippi John Hurt",
             "nombre_real": "unasigned",
             "perfil": "Influential country blues singer and guitarist.\r\nBorn: 8 March 1893 (exact birth date disputed) in Teoc, Carroll County, Mississippi\r\nDied: 2 November 1966 in Grenada, Mississippi, USA (heart attack)\r\n\r\nHis first recordings, made for Okeh Records in 1928, were commercial failures, and he continued to work as a farmer. Blues enthusiast located Hurt in 1963 and persuaded him to move to Washington, D.C. He was recorded by the Library of Congress in 1964. This helped further the American folk music revival, which led to the rediscovery of many other bluesmen of Hurt's era. He also went on to record several albums.",
@@ -4080,6 +4270,7 @@
     },
     {
         "release": {
+            "id": 256343,
             "titulo": "The Butterfield Blues Band* - Live",
             "url_imagen": "https://i.discogs.com/Hy-k2CLKa8AQy-5O9qgW0aBmYc_8fQ6bL4F6FOCwlZA/rs:fit/g:sm/q:90/h:533/w:526/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI1ODQz/NTAtMTM0NzUwNzY5/NS01NDM5LmpwZWc.jpeg",
             "sello": "7E-2001",
@@ -4136,6 +4327,7 @@
             }
         ],
         "artist": {
+            "id": 437880,
             "nombre": "The Paul Butterfield Blues Band",
             "nombre_real": "unasigned",
             "perfil": "US American blues rock band, formed in 1963 by [a=Paul Butterfield].",
@@ -4144,6 +4336,7 @@
     },
     {
         "release": {
+            "id": 584986,
             "titulo": "Buddy Guy - Rhythm & Blues",
             "url_imagen": "https://i.discogs.com/pR2BEtObF4boGDNq_N8FcGsRjJzx6ldWCjY1MgFrfUo/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTgwOTYy/NjItMTQ1NTA1NTk5/Ny03NDg3LmpwZWc.jpeg",
             "sello": "88883-71759-2",
@@ -4248,6 +4441,7 @@
             }
         ],
         "artist": {
+            "id": 259799,
             "nombre": "Buddy Guy",
             "nombre_real": "unasigned",
             "perfil": "American blues guitarist and singer, born July 30th, 1936 in Lettsworth, Louisiana, and one of the pioneers of the Chicago blues sound. Began performing with bands in Baton Rouge in the '50s before moving to Chicago in 1957. He originally recorded for [l=Cobra Record Corp.] subsidiary [l=Artistic (2)] before moving to [l=Chess], where he worked as a sideman and leader when Cobra folded. During his time on Chess he also recorded under the pseudonym Friendly Chap for [l=Delmark Records]. He moved to [l=Vanguard] in 1967, and then went on to work with a variety of labels. He is the brother of [a=Phil Guy].\r\n\r\nGuy has won six Grammy awards, 23 W.C. Handy Awards, and, in 2003, he was awarded the National Medal of Arts. He was inducted into the Rock And Roll Hall of Fame in 2005, and into the Louisiana Music Hall of Fame in 2008.",
@@ -4256,57 +4450,7 @@
     },
     {
         "release": {
-            "titulo": "B.B. King - Six Silver Strings",
-            "url_imagen": "https://i.discogs.com/u-lmz8nsnz2UK5UAhsZPSbOcxh6qAv-JjHf-YTAEido/rs:fit/g:sm/q:90/h:547/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE3ODA2/NTAtMTQ5Mjg4Njk2/Ni0xNzUyLmpwZWc.jpeg",
-            "sello": "MCA-5616",
-            "formato": "Vinyl",
-            "genero": "Blues",
-            "pais": "US",
-            "publicado": "1985"
-        },
-        "tracklist": [
-            {
-                "nombre": "Six Silver Strings",
-                "posicion": "A1"
-            },
-            {
-                "nombre": "Big Boss Man",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "In The Midnight Hour",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Into The Night",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "My Lucille",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Memory Lane",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "My Guitar Sings The Blues",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Double Trouble",
-                "posicion": "B4"
-            }
-        ],
-        "artist": {
-            "nombre": "B.B. King",
-            "nombre_real": "unasigned",
-            "perfil": "American blues singer, guitarist, and songwriter (September 16, 1925 near Itta Bena, Mississippi - May 14, 2015, Las Vegas, Nevada). \r\nB.B. is an abbreviation for 'Blues Boy'.\r\n\r\nKing is one of the most influential blues musicians of all time, earning the nickname \"The King of the Blues.\" He is considered one of the \"Three Kings of the Blues Guitar\" (along with [a=Albert King] and [a=Freddie King], none of whom are related). Since he started recording in the 1940s, he released over fifty albums. He previously worked as a tractor driver.\r\n\r\nIn his youth, he played on street corners for dimes, and would sometimes play in as many as four towns a night. In 1947, he hitchhiked to Memphis, TN, to pursue his music career. In Memphis, B.B. stayed with his cousin [a=Bukka White], one of the most celebrated blues performers of his time, who B.B. credits as one of his earliest mentors and teachers. King's first big break came in 1948 when he performed on [a=Sonny Boy Williamson]’s radio program on KWEM out of West Memphis. This radio performance led to steady engagements at the Sixteenth Avenue Grill in West Memphis and later to a ten-minute spot on the Memphis radio station WDIA. King's radio spot become so popular, it was expanded and became the “Sepia Swing Club.” As King worked at WDIA as a singer and disc jockey, he was given the catchy radio nickname \"Beale Street Blues Boy\", later shortened to \"Blues Boy\", and finally to \"B.B.\" \r\n\r\nIn the late 1940s and early 1950s, King was a part of the blues scene on Beale Street. \"Beale Street was where it all started for me\", King said. He performed with [a=Bobby Bland], [a=Johnny Ace], and [a=Earl Forest] in a group known as [a=The Beale Streeters]. In 1949, King made his recording debut on [l=Bullet (2)] ([l=Bullet Recording & Transcription Co.]) by issuing the single [url=https://www.discogs.com/release/7031392-BB-King-Miss-Martha-King-When-Your-Baby-Packs-Up-And-Goes]\"Miss Martha King\"[/url], which did not chart well. Later that year, he began a recording contract with Los Angeles-based [l=RPM Records (5)]. Many of King's early recordings were produced by [a=Sam Phillips (2)] (who later founded [l=Sun Record Company]). King's recording contract was followed by tours across the US, with performances in big city theatres as well as gigs in small clubs and juke joints in the southern United States. During one show in Twist, Arkansas, a fight broke out between two men and caused a fire. King evacuated with the rest of the crowd, but realizing he left his acoustic guitar inside, rushed back inside the burning building to retrieve it. He later discovered the two men were fighting over a woman named Lucille. Ever since, each one of B.B.’s trademark Gibson guitars has been called Lucille, as a reminder not to fight over women or run into any more burning buildings. \r\n\r\nIn 1952, B.B. had a number one hit with “Three O’Clock Blues,” and began touring nationally soon after. 1956 became a record-breaking year, with 342 concerts booked and three recording sessions. That same year he founded his own record label, [l=Blues Boys Kingdom], with headquarters at Beale Street in Memphis. In 1962, King signed to [l=ABC-Paramount] Records, which was later absorbed into [l=MCA Records]. In November 1964, King recorded the [m=107099] album, considered to be one of his finest recordings. In 1968, B.B. played at the [l=Newport Folk Festival] and at [a=Bill Graham (2)]’s [l=Fillmore West] on bills with the hottest contemporary rock artists of the day who idolized B.B. and helped to introduce him to a young white audience. In 1969, B.B. was chosen by [a=The Rolling Stones] as the opening act for their American tour. He won a 1970 Grammy Award for his version of the song \"The Thrill Is Gone\", which was a hit on both the Pop and R&B charts. It also gained the number 183 spot in Rolling Stone magazine's 500 Greatest Songs of All Time. From the 1980s until his death in 2015, he maintained a highly visible and active career, appearing on numerous television shows and performing as much as 300 nights a year.\r\n\r\nB.B. was inducted into the Blues Foundation Hall of Fame in 1984 and into the Rock And Roll Hall of Fame in 1987 (Performer).",
-            "url_imagen": "https://i.discogs.com/xV3Pd56I0RSs6P9ZS2SUz65Vuz8AxJU9HsiuMNDNbU0/rs:fit/g:sm/q:90/h:632/w:521/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTM3NzI5/LTEzMjg2MTE0Nzku/anBlZw.jpeg"
-        }
-    },
-    {
-        "release": {
+            "id": 263333,
             "titulo": "Keb' Mo' - Just Like You",
             "url_imagen": "https://i.discogs.com/F4fkuPz-H8pnWRdGJM4N_S_e3LEmuQ4RnvCUAoqMfnY/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE3NTM4/MTMtMTI0MTE2ODg0/NS5qcGVn.jpeg",
             "sello": "484117 2",
@@ -4371,6 +4515,7 @@
             }
         ],
         "artist": {
+            "id": 569276,
             "nombre": "Keb' Mo'",
             "nombre_real": "unasigned",
             "perfil": "Singer, songwriter, and guitarist born in south Los Angeles on October 3, 1951.",
@@ -4379,6 +4524,7 @@
     },
     {
         "release": {
+            "id": 1337628,
             "titulo": "Ben Harper And Charlie Musselwhite - No Mercy In This Land",
             "url_imagen": "https://i.discogs.com/vs79_nVZC6QSPvPvBpSuAdquFp_O7O242eDKBnWUiWI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNzY4/NTA1LTE1MjIwNTIx/MTQtMzg2Mi5qcGVn.jpeg",
             "sello": "7561-1",
@@ -4430,14 +4576,16 @@
             }
         ],
         "artist": {
+            "id": 42599,
             "nombre": "Ben Harper",
             "nombre_real": "unasigned",
-            "perfil": "Benjamin Chase Harper, professionally known as Ben Harper, is an American singer-songwriter and multi-instrumentalist born October 28, 1969 in Pomona, California, USA. He was married to [a=Laura Dern] from 2005 to 2013.",
+            "perfil": "Benjamin Charles Harper, professionally known as Ben Harper, is an American singer-songwriter and multi-instrumentalist born October 28, 1969 in Pomona, California, USA. He was married to [a=Laura Dern] from 2005 to 2013.",
             "url_imagen": "https://i.discogs.com/nIcGvgDn-5gp0FYMiAnuw4UbmnNqzgO6mI_9Hjt5_DQ/rs:fit/g:sm/q:90/h:520/w:520/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTQyNTk5/LTE2ODU0ODEwMzgt/NTEzMi5qcGVn.jpeg"
         }
     },
     {
         "release": {
+            "id": 306497,
             "titulo": "Sonny Boy Williamson (2) - The Real Folk Blues",
             "url_imagen": "https://i.discogs.com/yfdNFdXRxc6EpTJpvdbBXnXT0dyRRZUDjMkbEBBP_kY/rs:fit/g:sm/q:90/h:469/w:450/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI2NTYy/MjYtMTI5NTIxNzY5/NC5qcGVn.jpeg",
             "sello": "LP-1503",
@@ -4498,6 +4646,7 @@
             }
         ],
         "artist": {
+            "id": 287849,
             "nombre": "Sonny Boy Williamson (2)",
             "nombre_real": "unasigned",
             "perfil": "American blues singer & harmonica player at the emergence of 'electric blues'. Famous compositions include \"Help Me\", \"Eyesight To The Blind\" and \"Don't Start Me Talkin'\". Not to be confused with the earlier & more 'acoustic' [a746951] (of \"Good Morning, School Girl\" fame).\r\n\r\nSubsequent research has shown that Miller was born Aleck Ford on the Sara Jones Plantation in Tallahatchie County, Mississippi. He took on the name of his sharecropper stepfather, Jim Miller. His gravestone lists his date of birth as March 11, 1908. The stone erected by his sisters in Tutwiler, MS, lists his death as 23 June 1965. Such is the mystery of blues legends.\r\n\r\nAt BMI he is known as > Songwriter/Composer: WILLIAMSON WILLIE > Current Affiliation: BMI CAE/IPI #: 63518579.\r\nFor the songlist, please use the link below.\r\n\r\nBorn: December 05, 1899 // Glendora, Miss., United States.\r\nDied: May 25, 1965 // Helena, Ark., United States.",
@@ -4506,34 +4655,105 @@
     },
     {
         "release": {
-            "titulo": "Culture Club - Do You Really Want To Hurt Me",
-            "url_imagen": "https://i.discogs.com/ccnktdM1NypOuuC1GhUzy530-d80XY8lzyWsLpa-Y6o/rs:fit/g:sm/q:90/h:605/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTkxNjgz/ODAtMTQ3NTk3MDAz/My02NjgxLmpwZWc.jpeg",
-            "sello": "VS 518",
-            "formato": "Vinyl",
-            "genero": "Pop",
-            "pais": "UK",
-            "publicado": "1982",
-            "estilos": "New Wave, Reggae-Pop"
+            "id": 345165,
+            "titulo": "Joe Bonamassa - Live From The Royal Albert Hall",
+            "url_imagen": "https://i.discogs.com/V7Nx_hTi-HWGNJGGRVLa0hs6Gjjjgo4kMDThAcmNTMc/rs:fit/g:sm/q:90/h:500/w:500/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTI4NDk5/NzQtMTMwMzkxMzU2/My5qcGVn.jpeg",
+            "sello": "PRD 7274-2",
+            "formato": "CD",
+            "genero": "Blues",
+            "pais": "Europe",
+            "publicado": "2009",
+            "estilos": "Blues Rock, Classic Rock"
         },
         "tracklist": [
             {
-                "nombre": "Do You Really Want To Hurt Me",
-                "posicion": "A"
+                "nombre": "Django",
+                "posicion": "1-1"
             },
             {
-                "nombre": "Do You Really Want To Hurt Me (Dub Version)",
-                "posicion": "B"
+                "nombre": "The Ballad Of John Henry",
+                "posicion": "1-2"
+            },
+            {
+                "nombre": "So It's Like That",
+                "posicion": "1-3"
+            },
+            {
+                "nombre": "Last Kiss",
+                "posicion": "1-4"
+            },
+            {
+                "nombre": "So Many Roads",
+                "posicion": "1-5"
+            },
+            {
+                "nombre": "Stop!",
+                "posicion": "1-6"
+            },
+            {
+                "nombre": "Further On Up The Road",
+                "posicion": "1-7"
+            },
+            {
+                "nombre": "Woke Up Dreaming",
+                "posicion": "1-8"
+            },
+            {
+                "nombre": "High Water Everywhere",
+                "posicion": "1-9"
+            },
+            {
+                "nombre": "Sloe Gin",
+                "posicion": "1-10"
+            },
+            {
+                "nombre": "Lonesome Road Blues",
+                "posicion": "1-11"
+            },
+            {
+                "nombre": "Happier Times",
+                "posicion": "2-1"
+            },
+            {
+                "nombre": "Your Funeral My Trial",
+                "posicion": "2-2"
+            },
+            {
+                "nombre": "Blues Deluxe",
+                "posicion": "2-3"
+            },
+            {
+                "nombre": "Story Of A Quarryman",
+                "posicion": "2-4"
+            },
+            {
+                "nombre": "The Great Flood",
+                "posicion": "2-5"
+            },
+            {
+                "nombre": "Just Got Paid",
+                "posicion": "2-6"
+            },
+            {
+                "nombre": "Mountain Time",
+                "posicion": "2-7"
+            },
+            {
+                "nombre": "Asking Around For You",
+                "posicion": "2-8"
             }
         ],
         "artist": {
-            "nombre": "Culture Club",
+            "id": 900313,
+            "nombre": "Joe Bonamassa",
             "nombre_real": "unasigned",
-            "perfil": "UK pop group with reggae leanings, comprising [a=Boy George], vocals ([a=George O'Dowd], June 14, 1960), [a=Jon Moss], drums (September 11, 1957), [a=Roy Hay], guitar and keyboards (August 12, 1961) and [a=Michael Craig] (alias Mikey Craig), bass (February 15, 1960). The group split in 1986 and reformed in 1998.",
-            "url_imagen": "https://i.discogs.com/bxkZcbww0qdNSsqj0b9XHgjHmpTkwpgWGDc8wtvhfXQ/rs:fit/g:sm/q:90/h:481/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTk3MDYt/MTQzODU3NTA0My02/NTQ1LnBuZw.jpeg"
+            "perfil": "American blues rock guitarist, singer and songwriter.\r\nBorn May 8th, 1977 in New Hartford, NY, USA.\r\n\r\nHis career began onstage opening for B.B. King in 1989, when he was only 12 years old.\r\n\r\nFounder of [a6400986].",
+            "url_imagen": "https://i.discogs.com/WHP-CzgCsoj0F1AXqCEYdd5oJK7PHD9phWmKlqYr4LI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTkwMDMx/My0xNDU0ODA1NDI3/LTc4ODUuanBlZw.jpeg"
         }
     },
     {
         "release": {
+            "id": 871735,
             "titulo": "Melanie Martinez (2) - Cry Baby",
             "url_imagen": "https://i.discogs.com/DO9bIJX2O_acbLPDcemiSVHDGIMNlr5pxlzm-BvkDT0/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTc3NzM4/MjAtMTY0MDY2NjU3/NC0xMDUyLmpwZWc.jpeg",
             "sello": "549986-1",
@@ -4598,6 +4818,7 @@
             }
         ],
         "artist": {
+            "id": 4112839,
             "nombre": "Melanie Martinez (2)",
             "nombre_real": "unasigned",
             "perfil": "Melanie Martinez is a vocalist with a bent toward alternative singer/songwriter pop and electronic music, who is best known for competing on the third season of NBC's vocal competition The Voice. A native of Baldwin, New York, Martinez grew up listening to her father's Beatles records and hip-hop music. In 2012, while still in high school, Martinez auditioned for, and won a spot on, NBC's The Voice with her performance of Britney Spears' \"Toxic.\" Choosing to join judge Adam Levine's team, she eventually made it to week five before getting eliminated via audience vote. In 2014, Martinez released the Kinetics- and One Love-produced EP Dollhouse on Atlantic Records.",
@@ -4606,82 +4827,7 @@
     },
     {
         "release": {
-            "titulo": "Sam Smith (12) - In The Lonely Hour",
-            "url_imagen": "https://i.discogs.com/3EH_PfGJO5SkoZ5oCljstbzhkx4P54r3UVj8Me_xtww/rs:fit/g:sm/q:90/h:604/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY1MDYy/NTEtMTQyMDg5MDQ1/OC04MTczLmpwZWc.jpeg",
-            "sello": "3769173",
-            "formato": "CD",
-            "genero": "Pop",
-            "pais": "Europe",
-            "publicado": "2014",
-            "estilos": "Ballad, Europop, Synth-pop"
-        },
-        "tracklist": [
-            {
-                "nombre": "Money On My Mind",
-                "posicion": "1"
-            },
-            {
-                "nombre": "Good Thing",
-                "posicion": "2"
-            },
-            {
-                "nombre": "Stay With Me",
-                "posicion": "3"
-            },
-            {
-                "nombre": "Leave Your Lover",
-                "posicion": "4"
-            },
-            {
-                "nombre": "I'm Not The Only One",
-                "posicion": "5"
-            },
-            {
-                "nombre": "I've Told You Now",
-                "posicion": "6"
-            },
-            {
-                "nombre": "Like I Can",
-                "posicion": "7"
-            },
-            {
-                "nombre": "Life Support",
-                "posicion": "8"
-            },
-            {
-                "nombre": "Not In That Way",
-                "posicion": "9"
-            },
-            {
-                "nombre": "Lay Me Down",
-                "posicion": "10"
-            },
-            {
-                "nombre": "Restart",
-                "posicion": "11"
-            },
-            {
-                "nombre": "Latch (Acoustic)",
-                "posicion": "12"
-            },
-            {
-                "nombre": "La La La",
-                "posicion": "13"
-            },
-            {
-                "nombre": "Make It To Me",
-                "posicion": "14"
-            }
-        ],
-        "artist": {
-            "nombre": "Sam Smith (12)",
-            "nombre_real": "unasigned",
-            "perfil": "British Singer-songwriter, b. 19 May 1992, Bishop's Stortford. \r\nWinner of BBC's Sound of 2014 poll, despite hitting UK charts with collaborations as early as 2012. ",
-            "url_imagen": "https://i.discogs.com/_kgGwJ2ClIGV2sm5IRePVzIHXLuaTSPreTOtl9XlB_Y/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzNzYz/NzctMTY2Njc5ODgy/My0xODkzLmpwZWc.jpeg"
-        }
-    },
-    {
-        "release": {
+            "id": 1395162,
             "titulo": "Rex Orange County - Apricot Princess",
             "url_imagen": "https://i.discogs.com/9eGHAg62a1LuTenQpY2h7mNbWwC0BaUE_5dMedppSsI/rs:fit/g:sm/q:90/h:588/w:588/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTExNTYw/MTkxLTE1MTg1MDYy/NTMtNDg4Ni5qcGVn.jpeg",
             "sello": "AP001LP",
@@ -4734,6 +4880,7 @@
             }
         ],
         "artist": {
+            "id": 5729537,
             "nombre": "Rex Orange County",
             "nombre_real": "unasigned",
             "perfil": "Alex O'Connor (born May 4, 1998), better known by his stage name Rex Orange County, is an English singer-songwriter.",
@@ -4742,6 +4889,7 @@
     },
     {
         "release": {
+            "id": 103921,
             "titulo": "Phil Collins - You Can't Hurry Love",
             "url_imagen": "https://i.discogs.com/j3EYEFVNbMbZrYOocbgZj97CndIpOAT56H1_EUyq3EM/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNTE0/ODYtMTU0NDg3NDkw/NS02OTE1LmpwZWc.jpeg",
             "sello": "VS 531",
@@ -4762,6 +4910,7 @@
             }
         ],
         "artist": {
+            "id": 101028,
             "nombre": "Phil Collins",
             "nombre_real": "unasigned",
             "perfil": "British pop rock musician (drummer, singer, pianist), songwriter and actor, born 30 January 1951 in Chiswick, London, England, UK. Inducted into Songwriters Hall of Fame in 2003.\r\nBest known as a member of [a=Genesis], whom he joined in 1970 as a drummer, then becoming the lead vocalist in 1975 after the departure of [a=Peter Gabriel].\r\nHe began a solo career in 1981, while remaining a member of Genesis.\r\nFather of [a=Simon Collins] (with his first wife; marriage ended 1978); of [a=Lily Collins] (with his second wife [a=Jill Tavelman]; married, 4.8.1984, marriage ended, 1994); and of [a=Nicholas Collins] & [a=Mathew Collins] (with his third wife; married 1999, divorced 2008).\r\nHis brother was renowned cartoonist and illustrator [a=Clive Collins (4)] (MBE).",
@@ -4770,6 +4919,7 @@
     },
     {
         "release": {
+            "id": 49541,
             "titulo": "Captain & Tennille* - Love Will Keep Us Together",
             "url_imagen": "https://i.discogs.com/G78XPVfKPRGmy_-VHYPZPLEEU1sOva8NL0lLOBFn3OE/rs:fit/g:sm/q:90/h:602/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEyOTY4/MDQwLTE1NDczNDE1/NDAtODk2Mi5qcGVn.jpeg",
             "sello": "SP-4552",
@@ -4826,6 +4976,7 @@
             }
         ],
         "artist": {
+            "id": 151466,
             "nombre": "Captain And Tennille",
             "nombre_real": "unasigned",
             "perfil": "American act of great popularity in the mid to late 1970's.\r\n\r\nTheir heyday was hemmed in between their two #1 hits: [m=49550], the first single from their debut album of the same name, rose to the top spot in the summer of 1975 and has remained their signature song. They reached the top of the charts again with 1979's [m=49586], which hit #1 in early 1980.\r\n\r\nIn addition, they hosted their own television show on ABC for one season in 1976/77, but quit despite solid ratings to focus on recording and touring. \r\n\r\nIn July of 1976, they were invited by First Lady Betty Ford to perform in the East Room of the White House in the presence of Queen Elizabeth II and President Gerald Ford during the country's bicentennial celebration. After a long journey, Queen Elizabeth fell asleep during their show.\r\n\r\nA husband and wife duo, they divorced in 2014 after a 39 year marriage.",
@@ -4834,6 +4985,7 @@
     },
     {
         "release": {
+            "id": 74517,
             "titulo": "Barbra Streisand - Woman In Love",
             "url_imagen": "https://i.discogs.com/HYJMRMIQqwMFGUysTjehKBAaTZTbxUChiMgSqm1hs1E/rs:fit/g:sm/q:90/h:591/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTU4ODY0/NC0xNTM3MjIwNTAz/LTg5NjguanBlZw.jpeg",
             "sello": "1-11364",
@@ -4854,6 +5006,7 @@
             }
         ],
         "artist": {
+            "id": 53248,
             "nombre": "Barbra Streisand",
             "nombre_real": "unasigned",
             "perfil": "American singer-songwriter, author, actress, writer, film producer and director, born April 24, 1942 in Brooklyn, New York, United States. She was married to [a=Elliott Gould] from 1963-1970; their son is [a=Jason Gould]. She has been married to [a=James Brolin] since 1998. [a=Roslyn Kind] is her younger half-sister.",
@@ -4862,6 +5015,7 @@
     },
     {
         "release": {
+            "id": 72914,
             "titulo": "Paul Young - Come Back And Stay",
             "url_imagen": "https://i.discogs.com/h2GoP5ctLH-2M_SF716_GAqL7KVUFV0RGkOJH4dmW_Y/rs:fit/g:sm/q:90/h:609/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTkwNTUx/MTUtMTQ3Mzk4MDY5/My04MjE3LmpwZWc.jpeg",
             "sello": "A3636",
@@ -4882,6 +5036,7 @@
             }
         ],
         "artist": {
+            "id": 63617,
             "nombre": "Paul Young",
             "nombre_real": "unasigned",
             "perfil": "Pop-soul singer, born January 17, 1956, Luton, Bedfordshire, England.\r\nStarted out in 'Kool Kat & The Kool Kats' before joining [a=Streetband] who had the quirky hit 'Toast'. He then formed [a=The Q Tips] in 1979 performing over 700 concerts in the 3 years until going solo in 1982. It was third time lucky as the cover of [a=Marvin Gaye]'s \"Wherever I Lay My Hat\" hit No.1 in 1983, which was followed by the album \"No Parlez\" and established Paul with worldwide success.\r\n\r\nPaul Young's backing band is named [a=The Royal Family], and his backing vocalists are named [a=The Fabulous Wealthy Tarts].\r\n\r\nHe married [a=Stacey Young] (née Smith) in November 1988.\r\n",
@@ -4890,6 +5045,7 @@
     },
     {
         "release": {
+            "id": 73513,
             "titulo": "France Gall - Babacar",
             "url_imagen": "https://i.discogs.com/MCGIDk-iPdHHtSI2a9eza1eV6PRDqVa42wFAL2C8dac/rs:fit/g:sm/q:90/h:606/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTcyNzM3/OS0xNjYzOTM5OTA4/LTcxNjUuanBlZw.jpeg",
             "sello": "242 096-1",
@@ -4938,6 +5094,7 @@
             }
         ],
         "artist": {
+            "id": 257876,
             "nombre": "France Gall",
             "nombre_real": "unasigned",
             "perfil": "French singer born on October 9, 1947 in Paris and died on January 7, 2018 in Neuilly-Sur-Seine, France (infection / cancer) at the age of 70. Winner of the Eurovision Song Contest 1965 with the song \"Poupée De Cire, Poupée De Son\". She was married and had a successful career in partnership with French singer-songwriter [a1585851] (whose stage name was [a332485]).",
@@ -4946,6 +5103,7 @@
     },
     {
         "release": {
+            "id": 72600,
             "titulo": "Glenn Medeiros - Nothing's Gonna Change My Love For You",
             "url_imagen": "https://i.discogs.com/vyeFpfLLH4NWANI-vDzDqLJSkgQGYcy9gsSzn_Ln4Y0/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM0NjA2/MDYtMTUxODYzMDMz/NC0zNjk0LmpwZWc.jpeg",
             "sello": "AMHD 128",
@@ -4970,6 +5128,7 @@
             }
         ],
         "artist": {
+            "id": 120883,
             "nombre": "Glenn Medeiros",
             "nombre_real": "unasigned",
             "perfil": "American pop singer born on June 24, 1970, Lihue, Hawaii.",
@@ -4978,6 +5137,7 @@
     },
     {
         "release": {
+            "id": 86802,
             "titulo": "Nik Kershaw - I Won't Let The Sun Go Down",
             "url_imagen": "https://i.discogs.com/jw06ynhNaviIOQnOHyDTa2nhb0ldILDdER8XYNdg2fk/rs:fit/g:sm/q:90/h:597/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIxNzcw/MTQtMTQxMTkwNDk5/Ny02Mzc0LmpwZWc.jpeg",
             "sello": "MCA 816",
@@ -4998,6 +5158,7 @@
             }
         ],
         "artist": {
+            "id": 5647,
             "nombre": "Nik Kershaw",
             "nombre_real": "unasigned",
             "perfil": "British singer, composer and multi-instrumentalist (born on 1 March 1958).\r\nHe was born in Bristol as the younger son of a flautist and an opera singer. Kershaw grew up in Ipswich where he started to sing and play guitar in several bands until he became the today known solo artist.",
@@ -5006,6 +5167,7 @@
     },
     {
         "release": {
+            "id": 1295020,
             "titulo": "Bee Gees - Timeless - The All-Time Greatest Hits",
             "url_imagen": "https://i.discogs.com/H1SCl5ipyLufy4YeSZsFz87iBY_MlnYE-LxmhOR99es/rs:fit/g:sm/q:90/h:586/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwMTcx/NDM5LTE0OTI5NTA4/NzEtNjIwMS5qcGVn.jpeg",
             "sello": "00602557493597",
@@ -5101,6 +5263,7 @@
             }
         ],
         "artist": {
+            "id": 97664,
             "nombre": "Bee Gees",
             "nombre_real": "unasigned",
             "perfil": "A singing trio of brothers — [a151481], [a179142], and [a290019]. They were born on the Isle of Man to English parents, lived in Chorlton-cum-Hardy, Manchester, England, UK and during their childhood years moved to Brisbane, Australia, where they began their musical careers. Their worldwide success came when they returned to the UK and signed with producer [a272144].\r\n\r\nThe multiple award-winning group was successful for most of its forty years of recording music, but it had two distinct periods of exceptional success: as a harmonic 'soft rock' act in the late 1960s and early 1970s, and as the foremost stars of the disco music era in the late 1970s.\r\n\r\nNo matter the style, the Bee Gees sang three-part tight harmonies that were instantly recognizable; as brothers, their voices blended perfectly, in the same way that The Everly Brothers and Beach Boys did. Barry sang lead on many songs, in an R&B falsetto introduced in the disco years; Robin provided the clear vibrato lead that was a hallmark of their pre-disco music; Maurice sang high and low harmonies throughout their career. The three brothers co-wrote most of their hits, and they said that they felt like they became 'one person' when they were writing.\r\n\r\nIn 1994 [a746270] were inducted into the Songwriters Hall of Fame, in 1997 the Band was inducted into Rock And Roll Hall of Fame (Performer).\r\n\r\nThey were all given CBEs (Commander of the Order of the British Empire) in the 2001-2002 New Year's Honours List. The group's name was retired by the remaining brothers after Maurice died in January 2003.\r\n\r\nHowever, as time passed, they decided to perform occasionally under the Bee Gees banner until brother Robin Gibb died in May 2012.",
@@ -5109,6 +5272,7 @@
     },
     {
         "release": {
+            "id": 63016,
             "titulo": "Mylene Farmer* - Innamoramento",
             "url_imagen": "https://i.discogs.com/5V4vRdwKvYOjSq13IYi-CMBehg8fN0shjjgeCK8ScP0/rs:fit/g:sm/q:90/h:541/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEwNDg4/NzMtMTI5MzYxODM4/Ni5qcGVn.jpeg",
             "sello": "547 338 - 2",
@@ -5173,6 +5337,7 @@
             }
         ],
         "artist": {
+            "id": 106450,
             "nombre": "Mylène Farmer",
             "nombre_real": "unasigned",
             "perfil": "Mylène Jeanne Gautier, known by her stage name Mylène Farmer, is a French Canadian singer-songwriter, actress, and author, born on 12 September 1961 in Montreal, Quebec.",
@@ -5181,6 +5346,7 @@
     },
     {
         "release": {
+            "id": 36259,
             "titulo": "The Beautiful South - Carry On Up The Charts",
             "url_imagen": "https://i.discogs.com/7BfYqOSJ25SpZfx3kIET7UlL47iT6PM-Leg07nxsc2o/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY5NDg3/MS0xMjc2MzM2NTc3/LmpwZWc.jpeg",
             "sello": "828 572-2",
@@ -5249,6 +5415,7 @@
             }
         ],
         "artist": {
+            "id": 171427,
             "nombre": "The Beautiful South",
             "nombre_real": "unasigned",
             "perfil": "English alternative rock group formed at the end of the 1980s by two former members of Hull group [a245780]. The group broke up in January 2007.",
@@ -5257,6 +5424,7 @@
     },
     {
         "release": {
+            "id": 85601,
             "titulo": "The Carpenters* - The Singles 1974-1978",
             "url_imagen": "https://i.discogs.com/TfY9d4ZzhSfMr1cMXd9rdnv-DZFkn4y293IC5fl9j1Q/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTM5NjIy/Mi0xNTUyOTA4NDg4/LTQ0NjUuanBlZw.jpeg",
             "sello": "AMLT 19748",
@@ -5317,6 +5485,7 @@
             }
         ],
         "artist": {
+            "id": 170357,
             "nombre": "Carpenters",
             "nombre_real": "unasigned",
             "perfil": "American vocal and instrumental duo consisting of sister Karen, and brother Richard Carpenter.\r\n\r\nCarpenters were the #1 selling American music act of the 1970's. Though often referred to as \"The Carpenters,\" their name on official releases and press materials was \"Carpenters.\" During a period in the 1970's when louder and wilder rock was in great demand, Richard and Karen produced a distinctively soft musical style that made them among the best-selling music artists of all time.\r\n\r\nOriginally from New Haven, Connecticut, their parents decided to move the family west to Los Angeles, California. Richard and Karen originally played jazz, with Karen having an interest in playing the drums. They were briefly known as Spectrum and then Carpenters, where they then recorded for a small label, [l=Magic Lamp Records]. In their move West, they met Lou Adler who introduced them to [a=Herb Alpert], who signed them to his label, [l=A&M Records] in 1969.\r\n\r\nWhile Richard penned compositions with writing partner, [a=John Bettis], many of the duos' hits were written by others and some were cover versions of established hits for other artists, such as [a=The Beatles] and Motown's, [a=The Marvelettes]. Their 1973 album, \"Now and Then.\" B-side consists of a 9-song medley of 60's hits recorded like a radio show.\r\n\r\nCarpenters' melodic pop, produced a record-breaking run of hits on the American Top 40 and Adult Contemporary charts, and they became leading sellers in the soft rock, easy listening and adult contemporary genres. Carpenters had three #1 singles on the Billboard Hot 100 and fifteen #1 hits on the Adult Contemporary Chart. In addition, they had twelve top 10 singles (including their #1 hits). To date, Carpenters' album and single sales total more than 100 million units.\r\n\r\nDuring their 14-year career, Carpenters recorded 11 albums, five of which contained top 10 singles (\"[m=84990],\" \"[m=84975],\" \"[m=84966],\" \"[m=85055]\" and \"[m=85013],\") thirty-one singles, five television specials, and one short-lived television series. They toured the United States, United Kingdom, Japan, Australia, The Netherlands and Belgium. Their recording career ended with Karen's death in 1983 from cardiac arrest due to complications of anorexia nervosa. Extensive news coverage of the circumstances surrounding her death increased public awareness of the consequences of eating disorders. ",
@@ -5325,6 +5494,7 @@
     },
     {
         "release": {
+            "id": 55253,
             "titulo": "Cock Robin - When Your Heart Is Weak",
             "url_imagen": "https://i.discogs.com/FExKK4eNsIdjkYQ3MpXMbEPhBxJmjTfxZtxjOB9XnJE/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTY3MjQ2/OC0xMzc5NDUzNzUx/LTU3NzYuanBlZw.jpeg",
             "sello": "CBSA 6214",
@@ -5345,6 +5515,7 @@
             }
         ],
         "artist": {
+            "id": 166093,
             "nombre": "Cock Robin",
             "nombre_real": "unasigned",
             "perfil": "US Pop/Rock band, mostly popular in the 1980's, particularly in Europe. The band was founded in 1982 by singer/songwriter Peter Kingsbery. Originally with 4 members, Molino III and Wright left before the release of the band's second album in 1987. Kingsbery and LaCazio stayed on as a duo for a third album in 1989 but split up in 1990 after their Europe tour. After a 16-year hiatus, Kingsbery and LaCazio reformed Cock Robin in 2006 and released 2 more albums before LaCazio decided to leave in 2015 and relocate to the US. Cock Robin nowadays is fronted by Peter Kingsbery with Coralie Vuillemin as vocalist during live shows. A new album was released in March 2016 with additional vocals by Agathe Cagin and Julie Wingins. Drummers Marc Jacquemin and Didier Strub also complete the band line-up for live shows. A 5-track EP was released in April 2017 with 2 new original tracks (one instrumental), 2 covers from Peter Kingsbery's solo albums and 1 cover from Cock Robin's first album, with new arrangements and vocals by Kingsbery and Vuillemin. In September 2021, Cock Robin, consisting now of Kingsbery, Vuillemin and Strub, released a new 14-track album called \"Homo Alien\".\r\n\r\nBand settings :\r\nPeter Kingsbery: Lead vocals, Keyboards, Bass. (1982-1990 / 2006-present)\r\nAnna LaCazio: Lead vocals, Casio keyboards. (1982-1990 / 2006-2015)\r\nLouis Molino III: Drums, Percussion, backing vocals. (1982-1987)\r\nClive Wright: Guitars, Roland GR 300.(1982-1987 + On/off contributions)\r\nCoralie Vuillemin: Lead vocals, keyboards, percussions. (2015-present)\r\nDidier Strub: Drums (2015-present)\r\n\r\n",
@@ -5353,6 +5524,7 @@
     },
     {
         "release": {
+            "id": 2339365,
             "titulo": "FINNEAS - Optimist",
             "url_imagen": "https://i.discogs.com/eURhs96XvZMXWQtrXZtodSxp7TD2wQifZ0z_r08Dq-w/rs:fit/g:sm/q:90/h:542/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIwNTg0/NjQ1LTE2MzQyOTI2/OTMtMjMwMy5qcGVn.jpeg",
             "sello": "00602438604876",
@@ -5416,6 +5588,7 @@
             }
         ],
         "artist": {
+            "id": 5324432,
             "nombre": "FINNEAS",
             "nombre_real": "unasigned",
             "perfil": "Stage name of [a6016928] (born July 30, 1997). American actor, musician, and music producer. Brother of [a5590213].\r\n",
@@ -5424,6 +5597,7 @@
     },
     {
         "release": {
+            "id": 294514,
             "titulo": "The Bee Gees* - Spicks And Specks",
             "url_imagen": "https://i.discogs.com/wKlz4DmBe5Xy4BpaetKR0K74ThwdZSLXXHVPDVG4fWQ/rs:fit/g:sm/q:90/h:451/w:451/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTEzODYz/OTctMTIxNTE4ODQ1/MC5qcGVn.jpeg",
             "sello": "EL 32031",
@@ -5484,6 +5658,7 @@
             }
         ],
         "artist": {
+            "id": 97664,
             "nombre": "Bee Gees",
             "nombre_real": "unasigned",
             "perfil": "A singing trio of brothers — [a151481], [a179142], and [a290019]. They were born on the Isle of Man to English parents, lived in Chorlton-cum-Hardy, Manchester, England, UK and during their childhood years moved to Brisbane, Australia, where they began their musical careers. Their worldwide success came when they returned to the UK and signed with producer [a272144].\r\n\r\nThe multiple award-winning group was successful for most of its forty years of recording music, but it had two distinct periods of exceptional success: as a harmonic 'soft rock' act in the late 1960s and early 1970s, and as the foremost stars of the disco music era in the late 1970s.\r\n\r\nNo matter the style, the Bee Gees sang three-part tight harmonies that were instantly recognizable; as brothers, their voices blended perfectly, in the same way that The Everly Brothers and Beach Boys did. Barry sang lead on many songs, in an R&B falsetto introduced in the disco years; Robin provided the clear vibrato lead that was a hallmark of their pre-disco music; Maurice sang high and low harmonies throughout their career. The three brothers co-wrote most of their hits, and they said that they felt like they became 'one person' when they were writing.\r\n\r\nIn 1994 [a746270] were inducted into the Songwriters Hall of Fame, in 1997 the Band was inducted into Rock And Roll Hall of Fame (Performer).\r\n\r\nThey were all given CBEs (Commander of the Order of the British Empire) in the 2001-2002 New Year's Honours List. The group's name was retired by the remaining brothers after Maurice died in January 2003.\r\n\r\nHowever, as time passed, they decided to perform occasionally under the Bee Gees banner until brother Robin Gibb died in May 2012.",
@@ -5492,6 +5667,7 @@
     },
     {
         "release": {
+            "id": 36439,
             "titulo": "Aztec Camera - Oblivious",
             "url_imagen": "https://i.discogs.com/C5VXwYZugGre2iFhEyuRGblVmgKOb8YN_puRWAu1npk/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTMyNDU4/OC0xNTkwMDA0OTc3/LTY1MDcuanBlZw.jpeg",
             "sello": "RT 122",
@@ -5512,6 +5688,7 @@
             }
         ],
         "artist": {
+            "id": 73194,
             "nombre": "Aztec Camera",
             "nombre_real": "unasigned",
             "perfil": "Scottish new-wave/indie pop band founded by Roddy Frame in 1980 in East Kilbride, Scotland, United Kingdom. Disbanded in 1995.",
@@ -5520,70 +5697,195 @@
     },
     {
         "release": {
-            "titulo": "Bobby Vinton - Bobby Vinton's Greatest Hits",
-            "url_imagen": "https://i.discogs.com/1_Oskmby8PwTBOAHfTx67R0gKGY1Lt-wJhTVDUSe8lY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTIxOTYx/MjEtMTM1MDE3NzU4/Ni04MzE5LmpwZWc.jpeg",
-            "sello": "BN 26098",
+            "id": 80562,
+            "titulo": "Julio Iglesias & Willie Nelson - To All The Girls I've Loved Before",
+            "url_imagen": "https://i.discogs.com/Xa_XdN_C6dWK_w5ra2vh2buzmckaeeyA4GVT39kXiuY/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTUzMDQ2/My0xMzk1Nzk1NjM0/LTY2NDIuanBlZw.jpeg",
+            "sello": "A 4252",
             "formato": "Vinyl",
             "genero": "Pop",
-            "pais": "US",
-            "publicado": "1965",
-            "estilos": "Ballad, Vocal"
+            "pais": "UK",
+            "publicado": "1984",
+            "estilos": "Ballad"
         },
         "tracklist": [
             {
-                "nombre": "Blue Velvet",
-                "posicion": "A1"
+                "nombre": "To All The Girls I've Loved Before",
+                "posicion": "A"
             },
             {
-                "nombre": "Roses Are Red (My Love)",
-                "posicion": "A2"
-            },
-            {
-                "nombre": "Blue On Blue",
-                "posicion": "A3"
-            },
-            {
-                "nombre": "Mr. Lonely",
-                "posicion": "A4"
-            },
-            {
-                "nombre": "Let's Kiss And Make Up",
-                "posicion": "A5"
-            },
-            {
-                "nombre": "My Heart Belongs To Only You",
-                "posicion": "A6"
-            },
-            {
-                "nombre": "There! I've Said It Again",
-                "posicion": "B1"
-            },
-            {
-                "nombre": "Rain Rain Go Away",
-                "posicion": "B2"
-            },
-            {
-                "nombre": "I Love You The Way You Are",
-                "posicion": "B3"
-            },
-            {
-                "nombre": "Over The Mountain",
-                "posicion": "B4"
-            },
-            {
-                "nombre": "Trouble Is My Middle Name",
-                "posicion": "B5"
-            },
-            {
-                "nombre": "Tell Me Why",
-                "posicion": "B6"
+                "nombre": "I Don't Want To Wake You",
+                "posicion": "B"
             }
         ],
         "artist": {
-            "nombre": "Bobby Vinton",
+            "id": 67331,
+            "nombre": "Julio Iglesias",
             "nombre_real": "unasigned",
-            "perfil": "American pop music singer, born on April 16, 1935, in Canonsburg, Pennsylvania.",
-            "url_imagen": "https://i.discogs.com/1i6KRm38tN-xmQtWVIBE1ftII_Glo1JKj2gOdFjg9as/rs:fit/g:sm/q:90/h:718/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTE1NDk3/MS0xMzk1NTA1NTI0/LTE0ODguanBlZw.jpeg"
+            "perfil": "Spanish Singer-songwriter and Record producer.\r\n\r\nBorn September 23, 1943 in Madrid, Spain.\r\n",
+            "url_imagen": "https://i.discogs.com/6GVdVR7FSv2rQyprlj7w3x-iEpQGU8gyiqAnyQRK6G4/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY3MzMx/LTE2MjI5MTY5NTgt/NTgyNi5qcGVn.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 1830545,
+            "titulo": "Sam Smith (12) - Love Goes",
+            "url_imagen": "https://i.discogs.com/gxSgWbcGkZiCOLUR8gMCwdsoUJbuE41UTCYkr-zJxPQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE2MTM4/MDIzLTE2MDYwODI1/MTItODI1OS5qcGVn.jpeg",
+            "sello": "B003290402",
+            "formato": "CD",
+            "genero": "Pop",
+            "pais": "US",
+            "publicado": "2020"
+        },
+        "tracklist": [
+            {
+                "nombre": "Young",
+                "posicion": "1"
+            },
+            {
+                "nombre": "Diamonds",
+                "posicion": "2"
+            },
+            {
+                "nombre": "Another One",
+                "posicion": "3"
+            },
+            {
+                "nombre": "My Oasis",
+                "posicion": "4"
+            },
+            {
+                "nombre": "So Serious",
+                "posicion": "5"
+            },
+            {
+                "nombre": "Dance ('Til You Love Someone Else)",
+                "posicion": "6"
+            },
+            {
+                "nombre": "For The Lover That I Lost",
+                "posicion": "7"
+            },
+            {
+                "nombre": "Breaking Hearts",
+                "posicion": "8"
+            },
+            {
+                "nombre": "Forgive Myself",
+                "posicion": "9"
+            },
+            {
+                "nombre": "Love Goes ",
+                "posicion": "10"
+            },
+            {
+                "nombre": "Kids Again",
+                "posicion": "11"
+            },
+            {
+                "nombre": "Bonus Tracks",
+                "posicion": ""
+            },
+            {
+                "nombre": "Dancing With A Stranger",
+                "posicion": "12"
+            },
+            {
+                "nombre": "How Do You Sleep?",
+                "posicion": "13"
+            },
+            {
+                "nombre": "To Die For",
+                "posicion": "14"
+            },
+            {
+                "nombre": "I'm Ready",
+                "posicion": "15"
+            },
+            {
+                "nombre": "Fire On Fire",
+                "posicion": "16"
+            },
+            {
+                "nombre": "Promises",
+                "posicion": "17"
+            },
+            {
+                "nombre": "Sober",
+                "posicion": "18"
+            },
+            {
+                "nombre": "Laurel Canyon",
+                "posicion": "19"
+            }
+        ],
+        "artist": {
+            "id": 1376377,
+            "nombre": "Sam Smith (12)",
+            "nombre_real": "unasigned",
+            "perfil": "British Singer-songwriter, b. 19 May 1992, Bishop's Stortford. \r\nWinner of BBC's Sound of 2014 poll, despite hitting UK charts with collaborations as early as 2012. ",
+            "url_imagen": "https://i.discogs.com/_kgGwJ2ClIGV2sm5IRePVzIHXLuaTSPreTOtl9XlB_Y/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTEzNzYz/NzctMTY2Njc5ODgy/My0xODkzLmpwZWc.jpeg"
+        }
+    },
+    {
+        "release": {
+            "id": 80539,
+            "titulo": "Julio Iglesias - Hey!",
+            "url_imagen": "https://i.discogs.com/mYv45adgcZVpy1O4kurDMJdw_PITN0Jl539YCNoS6Ss/rs:fit/g:sm/q:90/h:614/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE3MTIy/MDktMTU1MTI5OTQ5/OC00NjYyLm1wbw.jpeg",
+            "sello": "S 84304",
+            "formato": "Vinyl",
+            "genero": "Pop",
+            "pais": "Spain",
+            "publicado": "1980",
+            "estilos": "Ballad"
+        },
+        "tracklist": [
+            {
+                "nombre": "Por Ella",
+                "posicion": "A1"
+            },
+            {
+                "nombre": "Amantes",
+                "posicion": "A2"
+            },
+            {
+                "nombre": "Morriñas",
+                "posicion": "A3"
+            },
+            {
+                "nombre": "Viejas Tradiciones",
+                "posicion": "A4"
+            },
+            {
+                "nombre": "Ron Y Coca Cola",
+                "posicion": "A5"
+            },
+            {
+                "nombre": "Hey",
+                "posicion": "B1"
+            },
+            {
+                "nombre": "Un Sentimental",
+                "posicion": "B2"
+            },
+            {
+                "nombre": "La Paloma Blanca",
+                "posicion": "B3"
+            },
+            {
+                "nombre": "La Nave Del Olvido",
+                "posicion": "B4"
+            },
+            {
+                "nombre": "Pajaro Chogüi",
+                "posicion": "B5"
+            }
+        ],
+        "artist": {
+            "id": 67331,
+            "nombre": "Julio Iglesias",
+            "nombre_real": "unasigned",
+            "perfil": "Spanish Singer-songwriter and Record producer.\r\n\r\nBorn September 23, 1943 in Madrid, Spain.\r\n",
+            "url_imagen": "https://i.discogs.com/6GVdVR7FSv2rQyprlj7w3x-iEpQGU8gyiqAnyQRK6G4/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTY3MzMx/LTE2MjI5MTY5NTgt/NTgyNi5qcGVn.jpeg"
         }
     }
 ]

--- a/src/api/endpoints/user_api.py
+++ b/src/api/endpoints/user_api.py
@@ -15,6 +15,7 @@ user_api = Blueprint('user_api', __name__)
 
 jwt_manager = JWTManager()
 
+
 @user_api.route('/signup', methods=['POST'])
 def signup():
 
@@ -233,14 +234,14 @@ def get_users():
         return jsonify({"error": "A ocurrido un error al intentar obtener usuarios: " + str(e)}), 500
 
 
-# @user_api.route('/delete_all', methods=['GET'])
-# def delete_all():
-#     User.query.delete()
-#     db.session.commit()
-
-#     return jsonify({"message": "Todos los usuarios han sido eliminados"})
+@user_api.route('/delete_all', methods=['GET'])
+def delete_all():
+    User.query.delete()
+    db.session.commit()
+    return jsonify({"message": "Todos los usuarios han sido eliminados"})
 
 # Desde aca Karai
+
 
 @user_api.route('/seller/<int:user_id>', methods=['PUT'])
 @jwt_required()
@@ -250,26 +251,27 @@ def update_sell_data(user_id):
     cliente_ID_paypal = request.json.get('cliente_ID_paypal')
     secret_key_paypal = request.json.get('secret_key_paypal')
     update_or_delete = request.json.get('update_or_delete')
-    
+
     user = User.query.get(user_id)
-    
+
     if user:
-        if update_or_delete == 'update': 
-            
+        if update_or_delete == 'update':
+
             user.cliente_ID_paypal = cliente_ID_paypal
             user.secret_key_paypal = secret_key_paypal
-            
+
             db.session.commit()
-            
+
         if update_or_delete == 'delete':
             user.cliente_ID_paypal = None
             user.secret_key_paypal = None
 
             db.session.commit()
-        
+
         return jsonify({"message": "Información actualizada correctamente."}), 200
     else:
         return jsonify({"message": "Usuario no encontrado."}), 404
+
 
 @user_api.route('/became_seller/<int:user_id>', methods=['PUT'])
 # @jwt_required()

--- a/src/api/endpoints/utils.py
+++ b/src/api/endpoints/utils.py
@@ -1,7 +1,12 @@
 """
 This module takes care of starting the API Server for users, Loading the DB and Adding the endpoints
 """
-import requests, time, secrets, string, os, json
+import requests
+import time
+import secrets
+import string
+import os
+import json
 from flask import Flask, request, jsonify, url_for, Blueprint, send_from_directory
 from api.models import db, Articulo, Tracks, Artista, User
 from api.utils import generate_sitemap, APIException
@@ -9,6 +14,7 @@ from werkzeug.security import generate_password_hash
 import cloudinary
 import cloudinary.uploader
 import cloudinary.api
+from urllib.parse import urlparse
 
 utils_api = Blueprint('utils_api', __name__)
 
@@ -16,21 +22,26 @@ utils_api = Blueprint('utils_api', __name__)
 Solo para pruebas iniciales. Este método no debería estar en productivo
 """
 
-#@utils_api.route('/cloud-test', methods=['GET'])
-def save_to_cloudinary(image_url, custom_public_id):
+
+def save_to_cloudinary(image_url, custom_public_id, isRelease):
     cloudinary.config(
         cloud_name='disco-stu',
         api_key='639893174366669',
         api_secret='NOzrJLcM6aktcSU7Qt32ocZR6ik'
     )
 
-    folder_path='images/'
+    folder_path = 'images/'
+
+    if isRelease:
+        folder_path += "releases/"
+    else:
+        folder_path += "artists/"
 
     try:
         upload_result = cloudinary.uploader.upload(
-        image_url, 
-        folder=folder_path,
-        public_id=custom_public_id)
+            image_url,
+            folder=folder_path,
+            public_id=custom_public_id)
 
         return upload_result["secure_url"]
     except cloudinary.exceptions.Error as e:
@@ -42,19 +53,23 @@ def save_to_cloudinary(image_url, custom_public_id):
         print("Cloudinary Uploader Error:", e)
         return jsonify({'message': "error al subir imagen"}), 500
 
+
 def save_initial_data_from_discosg(data):
     directory_name = "src/api/data"
     file_name = "data_inicial.json"
     folder_path = os.path.join(os.getcwd(), directory_name)
     file_path = os.path.join(folder_path, file_name)
-    
+
     with open(file_path, "w") as file:
         json.dump(data, file, indent=4, ensure_ascii=False)
 
+
 @utils_api.route('/execute_initial_data', methods=['GET'])
 def load_initial_file():
-    filename = os.getcwd() + "/src/api/data/data_inicial.json"  
+    filename = os.getcwd() + "/src/api/data/data_inicial.json"
     final_releases = None
+
+    print("inicializando inserciones...")
 
     with open(filename, "r") as file:
         final_releases = json.load(file)
@@ -73,36 +88,53 @@ def load_initial_file():
 
             if artista_data is not None:
                 artista = Artista(**artista_data)
-                
-            tracks = [Tracks(articulo=articulo, **track_data) for track_data in tracklist_data]
 
-            if artista is not None:
-                articulo.artista = artista
-
+            tracks = [Tracks(articulo=articulo, **track_data)
+                      for track_data in tracklist_data]
             articulo.tracks = tracks
 
             try:
-                image_release_name = filename = articulo.url_imagen.split("/")[-1]
-                articulo.url_imagen = save_to_cloudinary(articulo.url_imagen, image_release_name)
-                if artista is not None:
-                    image_artist_name = filename = artista.url_imagen.split("/")[-1]
-                    artista.url_imagen = save_to_cloudinary(artista.url_imagen, image_artist_name)
+                articulo.url_imagen = save_to_cloudinary(
+                    articulo.url_imagen, articulo.id, True)
+
+                existing_artista = db.session.query(
+                    Artista).filter_by(id=artista.id).first()
+                if not existing_artista:
+                    session.add(artista)
+                    artista.url_imagen = save_to_cloudinary(
+                        artista.url_imagen, artista.id, False)
+                    articulo.artista_id = artista.id
             except Exception as e:
                 return jsonify({'message': e})
 
-
             session.add(articulo)
-            if artista is not None:
-                session.add(artista)
             session.add_all(tracks)
-            session.commit()
+
+        session.commit()
 
         hashed_pass_admin = generate_password_hash("Admin123!")
         hashed_pass_user = generate_password_hash("User123!")
-        user_admin = User(usuario="Admin", nombre="Admin", correo="admin@discostu.com", contrasenha=hashed_pass_admin, is_admin=True)
-        user = User(usuario="User", nombre="User", correo="user@discostu.com", contrasenha=hashed_pass_user, is_admin=False)
+        user_admin = User(usuario="Admin", nombre="Admin",
+                          correo="admin@discostu.com",
+                          contrasenha=hashed_pass_admin,
+                          is_admin=True)
+        user = User(usuario="User", nombre="User",
+                    correo="user@discostu.com",
+                    contrasenha=hashed_pass_user,
+                    is_admin=False,
+                    pais_comprador="USA",
+                    valoracion="100",
+                    cantidad_de_valoraciones="367")
+        user2 = User(usuario="User2", nombre="User2",
+                     correo="user2@discostu.com",
+                     contrasenha=hashed_pass_user,
+                     is_admin=False,
+                     pais_comprador="BRASIL",
+                     valoracion="45",
+                     cantidad_de_valoraciones="129")
         session.add(user_admin)
         session.add(user)
+        session.add(user2)
         session.commit()
         print("inserción de datos e imagenes terminada")
     except Exception as e:
@@ -113,24 +145,27 @@ def load_initial_file():
 
     return jsonify(final_releases), 200
 
+
 """
 Ejecutar solo cuando no exista el archivo JSON inicial para generarlo
 """
+
+
 @utils_api.route('/load_initial_realeases', methods=['GET'])
 def load_initial_realeases():
     GENRES = ['electronic', 'rock', 'jazz', 'blues', 'pop']
     RECORDS_NUMBER = 20
     final_realases = []
-    
+
     print("Empezando extracción de datos de discosg...")
 
     for genre in GENRES:
-        url=f"https://api.discogs.com/database/search?genre={genre}&type=master&key=RXfBUdaMFaqAXOnguGZG&secret=mVbHxlSJOTEIiUJYPsFXSynoEpmtPHqB&per_page={RECORDS_NUMBER}&page=1"
+        url = f"https://api.discogs.com/database/search?genre={genre}&type=master&key=RXfBUdaMFaqAXOnguGZG&secret=mVbHxlSJOTEIiUJYPsFXSynoEpmtPHqB&per_page={RECORDS_NUMBER}&page=1"
 
         response_release = requests.get(url)
         data_general = response_release.json()
         data_release = data_general["results"]
-        #print("data_release: " + str(data_release))
+        # print("data_release: " + str(data_release))
 
         counter = 1
 
@@ -140,60 +175,72 @@ def load_initial_realeases():
 
             release_item = {}
             single_release = {}
+            single_release['id'] = release['id']
             single_release["titulo"] = release["title"]
             single_release["url_imagen"] = release["cover_image"]
-            #single_release["url_imagen"] = save_to_cloudinary(release["cover_image"], release["master_id"])
             single_release["sello"] = release["catno"]
             single_release["formato"] = release["format"][0]
-            if(release["genre"]):
-                single_release["genero"] = ", ".join(release["genre"]) if len(release["genre"]) > 1 else release["genre"][0]            
+            if (release["genre"]):
+                single_release["genero"] = ", ".join(release["genre"]) if len(
+                    release["genre"]) > 1 else release["genre"][0]
             single_release["pais"] = release["country"]
-            single_release["publicado"] = release.get("year", "unassigned") #DUDAS DE ESTE CAMPO
-            if(release["style"]):
-                single_release["estilos"] = ", ".join(release["style"]) if len(release["style"]) > 1 else release["style"][0]
+            single_release["publicado"] = release.get(
+                "year", "unassigned")  # DUDAS DE ESTE CAMPO
+            if (release["style"]):
+                single_release["estilos"] = ", ".join(release["style"]) if len(
+                    release["style"]) > 1 else release["style"][0]
+            if "videos" in release:
+                single_release["videos"] = release["videos"]
             release_item["release"] = single_release
 
-            #SE OBTIENE INFORMACIÓN MASTER DEL RELEASE
-            url_master = release["master_url"] + "?key=RXfBUdaMFaqAXOnguGZG&secret=mVbHxlSJOTEIiUJYPsFXSynoEpmtPHqB"
+            # SE OBTIENE INFORMACIÓN MASTER DEL RELEASE
+            url_master = release["master_url"] + \
+                "?key=RXfBUdaMFaqAXOnguGZG&secret=mVbHxlSJOTEIiUJYPsFXSynoEpmtPHqB"
             response_master = requests.get(url_master)
             data_master = response_master.json()
-            #print("data_master: " + str(data_master))
+            # print("data_master: " + str(data_master))
             tracklist = data_master.get("tracklist", [])
-            #print("tracklist: " + str(tracklist))
+            # print("tracklist: " + str(tracklist))
 
-            #SE OBTIENE INFORMACIÓN DEL TRACKLIST
-            new_tracklist =[]
+            # SE OBTIENE INFORMACIÓN DEL TRACKLIST
+            new_tracklist = []
             for track in tracklist:
                 new_track = {}
                 new_track["nombre"] = track["title"]
                 new_track["posicion"] = track["position"]
                 new_tracklist.append(new_track)
             release_item["tracklist"] = new_tracklist
-            
-            #SE OBTIENE INFORMACIÓN DEL ARTISTA        
+
+            # SE OBTIENE INFORMACIÓN DEL ARTISTA
             artist = data_master.get("artists", None)
             if artist is not None:
                 if artist and artist[0]["resource_url"]:
-                    url_artist = artist[0]["resource_url"] + "?key=RXfBUdaMFaqAXOnguGZG&secret=mVbHxlSJOTEIiUJYPsFXSynoEpmtPHqB"
+                    url_artist = artist[0]["resource_url"] + \
+                        "?key=RXfBUdaMFaqAXOnguGZG&secret=mVbHxlSJOTEIiUJYPsFXSynoEpmtPHqB"
                     response_artist = requests.get(url_artist)
                     data_artist = response_artist.json()
-                    #print("data_artist: " + str(data_artist));
+                    # print("data_artist: " + str(data_artist));
 
                     single_artist = {}
-                    single_artist["nombre"] = data_artist.get("name", "unasigned")
-                    single_artist["nombre_real"] = data_artist.get("nombre_real", "unasigned")
-                    single_artist["perfil"] = data_artist.get("profile", "unasigned")
+                    single_artist["id"] = data_artist["id"]
+                    single_artist["nombre"] = data_artist.get(
+                        "name", "unasigned")
+                    single_artist["nombre_real"] = data_artist.get(
+                        "nombre_real", "unasigned")
+                    single_artist["perfil"] = data_artist.get(
+                        "profile", "unasigned")
                     if "images" in data_artist and data_artist["images"]:
-                        single_artist["url_imagen"] = data_artist["images"][0].get("resource_url", "unasigned")
-                        #if data_artist["images"][0].get("resource_url", "unasigned") != "unasigned":
-                            #single_artist["url_imagen"] = save_to_cloudinary( data_artist["images"][0].get("resource_url"), data_artist["id"])
-                    #else:
-                        #single_artist["url_imagen"] = "unasigned"
-                
+                        single_artist["url_imagen"] = data_artist["images"][0].get(
+                            "resource_url", "unasigned")
+                        # if data_artist["images"][0].get("resource_url", "unasigned") != "unasigned":
+                        # single_artist["url_imagen"] = save_to_cloudinary( data_artist["images"][0].get("resource_url"), data_artist["id"])
+                    # else:
+                        # single_artist["url_imagen"] = "unasigned"
+
                 release_item["artist"] = single_artist
 
             final_realases.append(release_item)
-            #print("4 segundos para el siguiente fetch y evitar error 429...")
+            # print("4 segundos para el siguiente fetch y evitar error 429...")
             time.sleep(2)
     print("Extración de datos de discosg terminada...")
 


### PR DESCRIPTION
Se modifica Cludinary para separar imagenes de artículos y artístas
Se modica lógica de nombres de fotos ligados a los ids
Se modifica que no exista el mismo artísta. Actualmente repetía artístas
Se genera nuevo archivo de carga inicial donde vienen los ids
Se agregan 2 usuarios de prueba y un 1 admin a la carga inicial